### PR TITLE
Fixes #78 Fix required package

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ Work has begun on the MVP.
 
 Packit is written in python 3 and is supported only on 3.6 and later.
 
+When packit interacts with dist-git, it uses `fedpkg`, we suggest installing it:
+
+```bash
+sudo dnf install -y fedpkg
+```
 
 ## Installation
 

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -19,6 +19,7 @@
       - python3-libpagure
       - rpm-build
       - rebase-helper
+      - fedpkg
       state: present
   - name: Install latest twine for sake of check command
     pip:


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

Add to README.md required package `fedpkg`.
On clean system, it is not installed by default.