### PR TITLE
fix identation

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -92,7 +92,7 @@ class DistGit:
         """
         Perform a `git checkout`
         """
-       if git_ref in self.local_project.git_repo.heads:
+        if git_ref in self.local_project.git_repo.heads:
             head = self.local_project.git_repo.heads[git_ref]
         else:
             head = self.local_project.git_repo.create_head(git_ref, commit=f"remotes/origin/{git_ref}")


### PR DESCRIPTION
After installation of latest packit, it tracebacks on this:
```
Traceback (most recent call last):
  File "/root/.local/bin/packit", line 11, in <module>
    load_entry_point('packitos==0.1.dev240+gbbd7a9d', 'console_scripts', 'packit')()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
    def create_branch(self, branch_nane: str, base: str = "HEAD"):
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2793, in load_entry_point
    return ep.load()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2411, in load
    return self.resolve()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2417, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/root/.local/lib/python3.7/site-packages/packit/cli/packit_base.py", line 6, in <module>
    from packit.cli.update import update
  File "/root/.local/lib/python3.7/site-packages/packit/cli/update.py", line 10, in <module>
    from packit.api import PackitAPI
  File "/root/.local/lib/python3.7/site-packages/packit/api.py", line 10, in <module>
    from packit.distgit import DistGit
  File "/root/.local/lib/python3.7/site-packages/packit/distgit.py", line 95
    if git_ref in self.local_project.git_repo.heads:
                                                   ^
IndentationError: unindent does not match any outer indentation level
```