### PR TITLE
Fix watching upstream PRs

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -4,12 +4,9 @@ This is the official python interface for packit.
 
 import logging
 
-from rebasehelper.versioneer import versioneers_runner
-
 from packit.config import Config, PackageConfig
 from packit.distgit import DistGit
 from packit.upstream import Upstream
-
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +51,6 @@ class PackitAPI:
         )
 
         self.sync(
-            upstream=up,
             distgit=dg,
             commit_msg=f"Sync upstream pr: {pr_id}",
             pr_title=f"Upstream pr: {pr_id}",
@@ -102,7 +98,6 @@ class PackitAPI:
             dg.sync_files(up.local_project)
 
             self.sync(
-                upstream=up,
                 distgit=dg,
                 commit_msg=f"{full_version} upstream release",
                 pr_title=f"Update to upstream release {full_version}",
@@ -124,8 +119,6 @@ class PackitAPI:
         commit_msg_description: str = None,
         add_new_sources=False,
     ):
-        distgit.sync_files(upstream.local_project)
-        archive = distgit.download_upstream_archive()
 
         if add_new_sources:
             archive = distgit.download_upstream_archive()

--- a/packit/bot_api.py
+++ b/packit/bot_api.py
@@ -43,7 +43,7 @@ class PackitBotAPI:
         repo_name = fedmsg["msg"]["pull_request"]["head"]["repo"]["name"]
         namespace = fedmsg["msg"]["pull_request"]["head"]["repo"]["owner"]["login"]
         ref = fedmsg["msg"]["pull_request"]["head"]["ref"]
-        pr_id = fedmsg["msg"]["pull_request"]["id"]
+        pr_id = fedmsg["msg"]["pull_request"]["number"]
 
         github_repo = self._github_service.get_project(
             repo=repo_name, namespace=namespace
@@ -59,7 +59,7 @@ class PackitBotAPI:
             )
             return
         self.sync_upstream_pull_request(
-            package_config=package_config, pr_id=0, dist_git_branch=""
+            package_config=package_config, pr_id=pr_id, dist_git_branch="master"
         )
 
     def sync_upstream_pull_request(

--- a/packit/cli/packit_base.py
+++ b/packit/cli/packit_base.py
@@ -3,10 +3,9 @@ import logging
 import click
 from pkg_resources import get_distribution
 
-import packit
-from packit.cli.update import update
 from packit.cli.sourcegit_to_dist_git import sg2dg
 from packit.cli.sourcegit_to_srpm import sg2srpm
+from packit.cli.update import update
 from packit.cli.watch_fedora_ci import watcher
 from packit.cli.watch_sg_pr import watch_pr
 from packit.cli.watch_upstream_release import watch_releases
@@ -45,7 +44,7 @@ packit_base.add_command(sg2dg)
 packit_base.add_command(sg2srpm)
 packit_base.add_command(watcher)
 packit_base.add_command(version)
-packit_base.add_command(watch_pr)
+# packit_base.add_command(watch_pr)
 packit_base.add_command(watch_releases)
 packit_base.add_command(update)
 

--- a/packit/cli/watch_sg_pr.py
+++ b/packit/cli/watch_sg_pr.py
@@ -6,7 +6,7 @@ import logging
 
 import click
 
-from packit.api import PackitAPI
+from packit.bot_api import PackitBotAPI
 from packit.config import pass_config
 
 logger = logging.getLogger(__name__)
@@ -21,10 +21,10 @@ def watch_pr(config, message_id):
 
     :return: int, retcode
     """
-    api = PackitAPI(config)
+    api = PackitBotAPI(config)
     if message_id:
         for msg_id in message_id:
-            fedmsg_dict = api.fetch_fedmsg_dict(msg_id)
-            api.sync_upstream_pr_to_distgit(fedmsg_dict)
+            fedmsg_dict = api.consumerino.fetch_fedmsg_dict(msg_id)
+            api.sync_upstream_pull_request_with_fedmsg(fedmsg_dict)
     else:
-        api.keep_syncing_upstream_pulls()
+        api.watch_upstream_pull_request()

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -246,7 +246,6 @@ class DistGit:
             while line:
                 if line.startswith("Source"):
                     last_source_position = spec_file.tell()
-
                 line = spec_file.readline()
 
             if not last_source_position:

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -1,7 +1,9 @@
 import logging
+import os
 import shutil
 
 import git
+import requests
 
 from ogr.abstract import GitProject, GitService
 from packit.utils import is_git_repo, get_repo
@@ -21,7 +23,21 @@ class LocalProject:
         full_name: str = None,
         namespace: str = None,
         repo_name: str = None,
+        path_or_url: str = None,
     ) -> None:
+
+        if path_or_url:
+            if os.path.isdir(path_or_url):
+                working_dir = working_dir or path_or_url
+
+            try:
+                res = requests.get(path_or_url)
+                if res.ok:
+                    git_url = git_url or path_or_url
+                else:
+                    logger.warning("path_or_url is nor directory nor url")
+            except requests.exceptions.BaseHTTPError as ex:
+                logger.warning("path_or_url is nor directory nor url")
 
         self.git_repo = git_repo
         self.working_dir = working_dir

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -74,7 +74,11 @@ class Upstream:
         self, upstream: str, add_usptream_head_commit=False
     ) -> List[git.Commit]:
         """
-        Return the list of commits from current branch to upstream rev/tag.
+        Return the list of different commits between current branch and upstream rev/tag.
+
+        Always choosing the first-parent, so we have a line/path of the commits.
+        It contains merge-commits from the master and commits on top of the master.
+        (e.g. commits from PR)
 
         :param add_usptream_head_commit: bool
         :param upstream: str -- git branch or tag


### PR DESCRIPTION
- Improve LocalProject.
- Add back methods for patching.
- Fix watch-sg-pr CLI.
- Fix APIs for syncing PRs.


Using the old methods from Transformator, we should look at rebase-helper in the future.