### PR TITLE
Fixes #113 Packit is able to read packit.yaml

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,8 @@
-# `.packit.yaml` configuration file
+# Packit configuration file
 
 Packit uses a configuration file in the upstream repository. The config file is written in YAML language.
 
-You should place the file in the root of your upstream repo and name it `.packit.yaml`.
+You should place the file in the root of your upstream repo and name it `.packit.yaml` or `packit.yaml`.
 
 
 ## Values

--- a/docs/update.md
+++ b/docs/update.md
@@ -13,7 +13,7 @@ This is a detailed documentation for the update functionality of packit.
 
 ## Tutorial
 
-1. Place a file called `.packit.yaml` in the root of your upstream repository.
+1. Place a file called `.packit.yaml` or `packit.yaml` in the root of your upstream repository.
     * The configuration is described [in this document](/docs/configuration.md). TBD: write it!
     * Please get inspired from [an existing
       config](https://github.com/user-cont/colin/blob/master/.packit.yaml) in

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -1,3 +1,3 @@
 DG_PR_COMMENT_KEY_SG_PR = "Source-git pull request ID"
 DG_PR_COMMENT_KEY_SG_COMMIT = "Source-git commit"
-CONFIG_FILE_NAMES = [".packit.yaml", ".packit.yml", ".packit.json"]
+CONFIG_FILE_NAMES = [".packit.yaml", ".packit.yml", ".packit.json", "packit.yaml"]


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

This updates documentation and adds the ability to read also `packit.yaml` file.