### PR TITLE
Offline LocalProject and some CLI fixes

### DIFF
--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -29,7 +29,7 @@ def cover_packit_exception(_func=None, *, exit_code=None):
         def covered_func(config=None, *args, **kwargs):
             try:
                 if config:
-                    func(config, *args, **kwargs)
+                    func(config=config, *args, **kwargs)
                 else:
                     func(*args, **kwargs)
             except KeyboardInterrupt:

--- a/packit/config.py
+++ b/packit/config.py
@@ -71,7 +71,7 @@ def get_default_map_from_file() -> Optional[dict]:
 def get_context_settings() -> dict:
     return dict(
         help_option_names=["-h", "--help"],
-        auto_envvar_prefix="SOURCE_GIT",
+        auto_envvar_prefix="PACKIT",
         default_map=get_default_map_from_file(),
     )
 

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -24,13 +24,14 @@ class LocalProject:
         namespace: str = None,
         repo_name: str = None,
         path_or_url: str = None,
+        offline: bool = False,
     ) -> None:
 
         self.working_dir_temporary = False
         if path_or_url:
             if os.path.isdir(path_or_url):
                 working_dir = working_dir or path_or_url
-            else:
+            elif not offline:
                 try:
                     res = requests.head(path_or_url)
                     if res.ok:
@@ -71,13 +72,14 @@ class LocalProject:
                 and self.namespace
                 and self.git_service
                 and not self.git_project
+                and not offline
             ):
                 self.git_project = self.git_service.get_project(
                     repo=self.repo_name, namespace=self.namespace
                 )
                 change = True
 
-            if self.git_project and not self.git_service:
+            if self.git_project and not self.git_service and not offline:
                 self.git_service = self.git_project.service
                 change = True
 
@@ -100,7 +102,7 @@ class LocalProject:
                     self.git_repo = git.Repo(path=self.working_dir)
                     logger.debug("it's a git repo!")
                     change = True
-                elif self.git_url:
+                elif self.git_url and not offline:
                     self.git_repo = get_repo(
                         url=self.git_url, directory=self.working_dir
                     )
@@ -111,7 +113,12 @@ class LocalProject:
                     )
                     change = True
 
-            if self.git_url and not self.working_dir and not self.git_repo:
+            if (
+                self.git_url
+                and not self.working_dir
+                and not self.git_repo
+                and not offline
+            ):
                 self.git_repo = get_repo(url=self.git_url)
                 self.working_dir_temporary = True
                 change = True

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -123,7 +123,7 @@ class LocalProject:
                 self.working_dir_temporary = True
                 change = True
 
-            if self.git_project and not self.git_url:
+            if self.git_project and not self.git_url and not offline:
                 self.git_url = self.git_project.get_git_urls()["git"]
                 change = True
 


### PR DESCRIPTION
- Be able to set branch from option in LocalProjectParameter.
- Add offline mode to LocalProject.
- Use PACKIT prefix pro env variables used instead of cli options.

-----

- [ ] ~PackageConfig decorator for CLI functions~ I've played with this, but it would be too magic for saving three lines.
- [x] Tests for offline mode of LocalProject
- [x] Tests for `path_or_url` mode of LocalProject