### PR TITLE
implement srpm command

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,6 +3,7 @@ specfile_path: packit.spec
 synced_files:
   - packit.spec
   - .packit.yaml
-upstream_name: packit
-package_name: packit
-dist_git_url: https://src.fedoraproject.org/rpms/packit.git
+upstream_project_name: packitos
+downstream_package_name: packit
+current_version_command: ["python3", "setup.py", "--version"]
+create_tarball_command: ["python3", "setup.py", "sdist", "--dist-dir", "."]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ node('userspace-containerization'){
 
             stage ("Setup"){
                 onmyduffynode "yum -y install epel-release"
-                onmyduffynode "yum -y install python36-pip python36-devel git krb5-devel gcc rpm-build rpm-libs redhat-rpm-config"
+                onmyduffynode "yum -y install python36-pip python36-devel git krb5-devel gcc rpm-build rpm-libs redhat-rpm-config rpmdevtools"
                 onmyduffynode "yum -y remove git"
                 onmyduffynode "curl -o /etc/yum.repos.d/git-epel-7.repo https://copr.fedorainfracloud.org/coprs/g/git-maint/git/repo/epel-7/group_git-maint-git-epel-7.repo"
                 onmyduffynode "yum -y install git-core"

--- a/packit.spec
+++ b/packit.spec
@@ -14,7 +14,10 @@ BuildRequires:  python3-devel
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(setuptools-scm)
 BuildRequires:  python3dist(setuptools-scm-git-archive)
+# new-sources
 Requires:       fedpkg
+# bumpspec
+Requires:       rpmdevtools
 Requires:       python3-%{real_name} = %{version}-%{release}
 
 %?python_enable_dependency_generator

--- a/packit/api.py
+++ b/packit/api.py
@@ -226,11 +226,11 @@ class PackitAPI:
         spec_version = up.get_specfile_version()
         up.create_archive()
         if version != spec_version:
-            up.bump_spec(version=version, changelog_entry="Development snapshot")
-            # sadly rebase-helper can't do the job easily now:
-            # * it creates a bunch of dirs we don't need: BUILD, BUILDROOT, RPMS
-            # * the API is complicated to be used
-            # * I can't make it to add a changelog comment
-            # up.set_spec_version(version=version, changelog_entry="Development snapshot")
+            try:
+                # sadly rebase-helper can't do the job easily now:
+                # * it creates a bunch of dirs we don't need: BUILD, BUILDROOT, RPMS
+                up.set_spec_version(version=version, changelog_entry="- Development snapshot")
+            except PackitException:
+                up.bump_spec(version=version, changelog_entry="Development snapshot")
         srpm_path = up.create_srpm(srpm_path=output_file)
         return srpm_path

--- a/packit/api.py
+++ b/packit/api.py
@@ -227,8 +227,6 @@ class PackitAPI:
         up.create_archive()
         if version != spec_version:
             try:
-                # sadly rebase-helper can't do the job easily now:
-                # * it creates a bunch of dirs we don't need: BUILD, BUILDROOT, RPMS
                 up.set_spec_version(version=version, changelog_entry="- Development snapshot")
             except PackitException:
                 up.bump_spec(version=version, changelog_entry="Development snapshot")

--- a/packit/api.py
+++ b/packit/api.py
@@ -213,3 +213,24 @@ class PackitAPI:
             update_notes=update_notes,
             update_type=update_type,
         )
+
+    def create_srpm(self, output_file: str = None) -> Path:
+        """
+        Create srpm from the upstream repo
+
+        :param output_file: path + filename where the srpm should be written, defaults to cwd
+        :return: a path to the srpm
+        """
+        up = Upstream(config=self.config, package_config=self.package_config)
+        version = up.get_current_version()
+        spec_version = up.get_specfile_version()
+        up.create_archive()
+        if version != spec_version:
+            up.bump_spec(version=version, changelog_entry="Development snapshot")
+            # sadly rebase-helper can't do the job easily now:
+            # * it creates a bunch of dirs we don't need: BUILD, BUILDROOT, RPMS
+            # * the API is complicated to be used
+            # * I can't make it to add a changelog comment
+            # up.set_spec_version(version=version, changelog_entry="Development snapshot")
+        srpm_path = up.create_srpm(srpm_path=output_file)
+        return srpm_path

--- a/packit/cli/packit_base.py
+++ b/packit/cli/packit_base.py
@@ -3,8 +3,9 @@ import logging
 import click
 from pkg_resources import get_distribution
 
-from packit.cli.create_update import create_update
 from packit.cli.build import build
+from packit.cli.create_update import create_update
+from packit.cli.srpm import srpm
 from packit.cli.update import update
 from packit.cli.watch_upstream_release import watch_releases
 from packit.config import Config, get_context_settings
@@ -47,6 +48,7 @@ packit_base.add_command(watch_releases)
 packit_base.add_command(update)
 packit_base.add_command(build)
 packit_base.add_command(create_update)
+packit_base.add_command(srpm)
 
 if __name__ == "__main__":
     packit_base()

--- a/packit/cli/srpm.py
+++ b/packit/cli/srpm.py
@@ -1,0 +1,31 @@
+import logging
+import os
+
+import click
+
+from packit.cli.types import LocalProjectParameter
+from packit.cli.utils import cover_packit_exception, get_packit_api
+from packit.config import pass_config, get_context_settings
+
+logger = logging.getLogger("packit")
+
+
+@click.command("srpm", context_settings=get_context_settings())
+@click.option(
+    "--output", metavar="FILE", help="Write the SRPM to FILE instead of current dir."
+)
+@click.argument(
+    "path_or_url", type=LocalProjectParameter(), default=os.path.abspath(os.path.curdir)
+)
+@pass_config
+@cover_packit_exception
+def srpm(config, output, path_or_url):
+    """
+    Create new SRPM (.src.rpm file) using content of the upstream repository.
+
+    PATH_OR_URL argument is a local path or a URL to the upstream git repository,
+    it defaults to the current working directory
+    """
+    api = get_packit_api(config=config, local_project=path_or_url)
+    srpm_path = api.create_srpm(output_file=output)
+    logger.info("SRPM: %s", srpm_path)

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -1,5 +1,9 @@
 import logging
 import os
+import re
+import shutil
+import tempfile
+from pathlib import Path
 from typing import Optional, List, Tuple
 
 import git
@@ -178,12 +182,12 @@ class Upstream:
     def get_specfile_version(self) -> str:
         """ provide version from specfile """
         version = self.specfile.get_full_version()
-        logger.info(f'Version in spec file is "f{version}".')
+        logger.info(f'Version in spec file is "{version}".')
         return version
 
     def get_version(self) -> str:
         """
-        Return version of latest release: prioritize upstream
+        Return version of the latest release available: prioritize upstream
         package repositories over the version in spec
         """
         ups_ver = self.get_latest_released_version()
@@ -195,3 +199,127 @@ class Upstream:
             )
             return ups_ver
         return spec_ver
+
+    def get_current_version(self) -> str:
+        """
+        Get version of the project in current state (hint `git describe`)
+
+        :return: e.g. 0.1.1.dev86+ga17a559.d20190315 or 0.6.1.1.gce4d84e
+        """
+        ver = run_command(
+            self.package_config.current_version_command, output=True
+        ).strip()
+        logger.debug("version = %s", ver)
+        # FIXME: this might not work when users expect the dashes
+        #  but! RPM refuses dashes in version/release
+        ver = ver.replace("-", ".")
+        logger.debug("sanitized version = %s", ver)
+        return ver
+
+    def bump_spec(self, version: str = None, changelog_entry: str = None):
+        """
+        Run rpmdev-bumpspec on the upstream spec file: it enables
+        changing version and adding a changelog entry
+
+        :param version: new version which should be present in the spec
+        :param changelog_entry: new changelog entry (just the comment)
+        """
+        cmd = ["rpmdev-bumpspec"]
+        if version:
+            # 1.2.3-4 means, version = 1.2.3, release = 4
+            cmd += ["--new", version]
+        if changelog_entry:
+            cmd += ["--comment", changelog_entry]
+        cmd.append(self.specfile_path)
+        run_command(cmd)
+
+    def set_spec_version(self, version: str, changelog_entry: str):
+        """
+        Set version in spec and add a changelog_entry.
+
+        :param version: new version
+        :param changelog_entry: accompanying changelog entry
+        """
+        # We can't change the version in-place:
+        # https://github.com/rebase-helper/rebase-helper/pull/596
+        # also this code adds 3 rpmbuild dirs into the upstream repo,
+        # we should ask rebase-helper not to do that
+        tmpdir = Path(tempfile.mkdtemp())
+        try:
+            new_path = tmpdir / "spec"
+            shutil.copy2(self.specfile_path, new_path)
+            tmpspec = SpecFile(
+                new_path, changelog_entry=changelog_entry, download=False
+            )
+            tmpspec.set_version(version=version)
+            tmpspec.save()
+            self._specfile = tmpspec.copy(self.specfile_path)
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def create_archive(self):
+        """
+        Create archive, using `git archive` by default, from the content of the upstream
+        repository, only committed changes are present in the archive
+        """
+        if self.package_config.upstream_project_name:
+            dir_name = f"{self.package_config.upstream_project_name}-{self.get_current_version()}"
+        else:
+            dir_name = f"{self.package_name}-{self.get_current_version()}"
+        logger.debug("name + version = %s", dir_name)
+        # We don't care about the name of the archive, really
+        # we just require for the archive to be placed in the cwd
+        if self.package_config.create_tarball_command:
+            archive_cmd = self.package_config.create_tarball_command
+        else:
+            # FIXME: .tar.gz is naive
+            archive_name = f"{dir_name}.tar.gz"
+            archive_cmd = [
+                "git",
+                "archive",
+                "-o",
+                archive_name,
+                "--prefix",
+                f"{dir_name}/",
+                "HEAD",
+            ]
+        run_command(archive_cmd)
+
+    def create_srpm(self, srpm_path: str = None) -> Path:
+        """
+        Create SRPM from the actual content of the repo
+
+        :param srpm_path: path to the srpm
+        :return: path to the srpm
+        """
+        cwd = os.getcwd()
+        cmd = [
+            "rpmbuild",
+            "-bs",
+            "--define",
+            f"_sourcedir {cwd}",
+            "--define",
+            f"_specdir {cwd}",
+            "--define",
+            f"_srcrpmdir {cwd}",
+            # no idea about this one, but tests were failing in tox w/o it
+            "--define",
+            f"_topdir {cwd}",
+            self.specfile_path,
+        ]
+        present_srpms = set(Path.cwd().glob("*.src.rpm"))
+        logger.debug("present srpms = %s", present_srpms)
+        out = run_command(
+            cmd,
+            output=True,
+            error_message="SRPM could not be created. Is the archive present?",
+        ).strip()
+        reg = r"Wrote: (.+)$"
+        try:
+            the_srpm = re.findall(reg, out)[0]
+        except IndexError:
+            raise PackitException("SRPM cannot be found, something is wrong.")
+        if srpm_path:
+            Path(the_srpm).rename(srpm_path)
+            return Path(srpm_path)
+        return Path(the_srpm)

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -303,6 +303,13 @@ class Upstream:
             # no idea about this one, but tests were failing in tox w/o it
             "--define",
             f"_topdir {cwd}",
+            # we also need these 3 so that rpmbuild won't create them
+            "--define",
+            f"_builddir {cwd}",
+            "--define",
+            f"_rpmdir {cwd}",
+            "--define",
+            f"_buildrootdir {cwd}",
             self.specfile_path,
         ]
         present_srpms = set(Path.cwd().glob("*.src.rpm"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import datetime
 import shutil
 import subprocess
 import sys
+from os import chdir
 from pathlib import Path
 
 import pytest
@@ -11,10 +12,12 @@ from ogr.services.github import GithubService
 from ogr.services.pagure import PagureProject, PagureService
 from rebasehelper.specfile import SpecFile
 
+from packit.api import PackitAPI
 from packit.config import get_local_package_config
 from packit.distgit import DistGit
+from packit.upstream import Upstream
 from packit.utils import FedPKG
-from tests.spellbook import prepare_dist_git_repo
+from tests.spellbook import prepare_dist_git_repo, get_test_config
 from .spellbook import TARBALL_NAME, UPSTREAM, git_add_n_commit, DISTGIT
 
 
@@ -96,3 +99,31 @@ def upstream_n_distgit(tmpdir):
     prepare_dist_git_repo(d)
 
     return u, d
+
+
+@pytest.fixture()
+def upstream_instance(upstream_n_distgit):
+    u, d = upstream_n_distgit
+
+    chdir(u)
+    c = get_test_config()
+
+    pc = get_local_package_config(str(u))
+    pc.upstream_project_url = str(u)
+
+    ups = Upstream(c, pc)
+    return u, ups
+
+
+@pytest.fixture()
+def api_instance(upstream_n_distgit):
+    u, d = upstream_n_distgit
+
+    chdir(u)
+    c = get_test_config()
+
+    pc = get_local_package_config(str(u))
+    pc.upstream_project_url = str(u)
+
+    api = PackitAPI(c, pc)
+    return u, d, api

--- a/tests/data/upstream_git/.packit.json
+++ b/tests/data/upstream_git/.packit.json
@@ -17,7 +17,7 @@
       ]
     }
   ],
-  "upstream_project_name": "beer",
+  "upstream_project_name": "beerware",
   "downstream_package_name": "beer",
   "checks": [
     {

--- a/tests/functional/test_srpm.py
+++ b/tests/functional/test_srpm.py
@@ -1,0 +1,18 @@
+"""
+Functional tests for srpm comand
+"""
+
+from tests.spellbook import call_real_packit
+
+
+def test_srpm_command(upstream_instance):
+    u, ups = upstream_instance
+    call_real_packit(parameters=["--debug", "srpm"], cwd=u)
+    assert list(u.glob("*.src.rpm"))[0].exists()
+
+
+def test_srpm_custom_path(upstream_instance):
+    u, ups = upstream_instance
+    custom_path = "sooooorc.rpm"
+    call_real_packit(parameters=["--debug", "srpm", "--output", custom_path], cwd=u)
+    assert u.joinpath(custom_path).is_file()

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,0 +1,17 @@
+"""    custom_path = "sooooorc.rpm"
+Functional tests for srpm comand
+"""
+from pathlib import Path
+
+
+def test_srpm(api_instance):
+    u, d, api = api_instance
+    api.create_srpm()
+    assert list(Path.cwd().glob("*.src.rpm"))[0].exists()
+
+
+def test_srpm_custom_path(api_instance):
+    u, d, api = api_instance
+    custom_path = "sooooorc.rpm"
+    api.create_srpm(output_file=custom_path)
+    assert Path.cwd().joinpath(custom_path).is_file()

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -1,46 +1,88 @@
 """
 Tests for Upstream class
 """
-from os import chdir
+import re
+import subprocess
+from pathlib import Path
 
 import pytest
 from flexmock import flexmock
 from rebasehelper.versioneer import versioneers_runner
 
-from packit.config import get_local_package_config
-from packit.upstream import Upstream
-from tests.spellbook import get_test_config
+from packit.exceptions import PackitException
+from tests.spellbook import does_bumpspec_know_new
 
 
-def test_basic_local_update(upstream_n_distgit):
-    """ basic propose-update test: mock remote API, use local upstream and dist-git """
-    u, d = upstream_n_distgit
-
-    chdir(u)
-    c = get_test_config()
-
-    pc = get_local_package_config(str(u))
-    pc.upstream_project_url = str(u)
-
-    ups = Upstream(c, pc)
-
+def test_get_spec_version(upstream_instance):
+    u, ups = upstream_instance
     assert ups.get_specfile_version() == "0.1.0"
+
+
+def test_get_current_version(upstream_instance):
+    u, ups = upstream_instance
+
+    assert ups.get_current_version() == "0.1.0"
 
 
 @pytest.mark.parametrize(
     "m_v,exp", (("1.1000.1000000", "1.1000.1000000"), (None, "0.1.0"))
 )
-def test_get_version(upstream_n_distgit, m_v, exp):
-    u, d = upstream_n_distgit
-
-    chdir(u)
-    c = get_test_config()
-
-    pc = get_local_package_config(str(u))
-    pc.upstream_project_url = str(u)
-
-    ups = Upstream(c, pc)
-
+def test_get_version(upstream_instance, m_v, exp):
+    u, ups = upstream_instance
     flexmock(versioneers_runner, run=lambda **kw: m_v)
 
     assert ups.get_version() == exp
+
+    u.joinpath("README").write_text("\nEven better now!\n")
+    subprocess.check_call(["git", "add", "."], cwd=u)
+    subprocess.check_call(["git", "commit", "-m", "More awesome changes"], cwd=u)
+
+    # 0.1.0.1.ge98cee1
+    assert re.match(r"0\.1\.0\.1\.\w{8}", ups.get_current_version())
+
+
+@pytest.mark.skipif(
+    not does_bumpspec_know_new(),
+    reason="Current version of rpmdev-bumpspec doesn't understand --new option.",
+)
+def test_bumpspec(upstream_instance):
+    u, ups = upstream_instance
+
+    new_ver = "1.2.3"
+    ups.bump_spec(version=new_ver, changelog_entry="asdqwe")
+
+    assert ups.get_specfile_version() == new_ver
+
+
+def test_create_archive(upstream_instance):
+    """ basic propose-update test: mock remote API, use local upstream and dist-git """
+    u, ups = upstream_instance
+
+    ups.create_archive()
+
+    assert u.glob("*.tar.gz")
+
+    u.joinpath("README").write_text("\nEven better now!\n")
+    subprocess.check_call(["git", "add", "."], cwd=u)
+    subprocess.check_call(["git", "commit", "-m", "More awesome changes"], cwd=u)
+
+    ups.create_archive()
+
+    assert len(list(u.glob("*.tar.gz"))) == 2
+
+
+def test_create_srpm(upstream_instance, tmpdir):
+    u, ups = upstream_instance
+
+    with pytest.raises(PackitException) as exc:
+        ups.create_srpm()
+    assert "SRPM could not be created. Is the archive present?" in str(exc.value)
+
+    ups.create_archive()
+    srpm = ups.create_srpm()
+
+    assert srpm.exists()
+
+    srpm_path = Path(tmpdir).joinpath("custom.src.rpm")
+    srpm = ups.create_srpm(srpm_path=srpm_path)
+    assert srpm.exists()

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -54,8 +54,17 @@ def test_bumpspec(upstream_instance):
     assert ups.get_specfile_version() == new_ver
 
 
+def test_set_spec_ver(upstream_instance):
+    u, ups = upstream_instance
+
+    new_ver = "1.2.3"
+    ups.set_spec_version(version=new_ver, changelog_entry="- asdqwe")
+
+    assert ups.get_specfile_version() == new_ver
+    assert "- asdqwe" in u.joinpath("beer.spec").read_text()
+
+
 def test_create_archive(upstream_instance):
-    """ basic propose-update test: mock remote API, use local upstream and dist-git """
     u, ups = upstream_instance
 
     ups.create_archive()

--- a/tests/spellbook.py
+++ b/tests/spellbook.py
@@ -4,6 +4,9 @@ A book with our finest spells
 import subprocess
 from pathlib import Path
 
+from click.testing import CliRunner
+
+from packit.cli.packit_base import packit_base
 from packit.config import Config
 
 
@@ -43,6 +46,7 @@ def git_add_n_commit(
     :param push: push to the remote?
     """
     subprocess.check_call(["git", "init", "."], cwd=directory)
+    Path(directory).joinpath("README").write_text("Best upstream project ever!")
     git_set_user_email(directory)
     subprocess.check_call(["git", "add", "."], cwd=directory)
     subprocess.check_call(["git", "commit", "-m", "initial commit"], cwd=directory)
@@ -72,3 +76,24 @@ def can_a_module_be_imported(module_name):
         return True
     except ImportError:
         return False
+
+
+def call_packit(fnc=None, parameters=None, envs=None):
+    fnc = fnc or packit_base
+    runner = CliRunner()
+    envs = envs or {}
+    parameters = parameters or []
+    # catch exceptions enables debugger
+    return runner.invoke(fnc, args=parameters, env=envs, catch_exceptions=False)
+
+
+def call_real_packit(parameters=None, envs=None, cwd=None):
+    """ invoke packit in a subprocess """
+    cmd = ["python3", "-m", "packit.cli.packit_base"] + parameters
+    return subprocess.check_call(cmd, env=envs, cwd=cwd)
+
+
+def does_bumpspec_know_new():
+    """ does rpmdev-bumpspec know --new? """
+    h = subprocess.check_output(["rpmdev-bumpspec", "--help"])
+    return b"--new" in h

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,4 @@
 import pytest
-from click.testing import CliRunner
 
 from packit.cli.build import build
 from packit.cli.create_update import create_update
@@ -7,35 +6,26 @@ from packit.cli.packit_base import packit_base
 from packit.cli.packit_base import version as cli_version
 from packit.cli.update import update
 from packit.cli.watch_upstream_release import watch_releases
-
-
-def _call_packit(fnc=None, parameters=None, envs=None):
-    fnc = fnc or packit_base
-    runner = CliRunner()
-    envs = envs or {}
-    if not parameters:
-        return runner.invoke(fnc, env=envs)
-    else:
-        return runner.invoke(fnc, parameters, env=envs)
+from tests.spellbook import call_packit
 
 
 def test_base_help():
-    result = _call_packit(parameters=["--help"])
+    result = call_packit(parameters=["--help"])
     assert result.exit_code == 0
     assert "Usage: packit [OPTIONS] COMMAND [ARGS]..." in result.output
 
 
 def test_base_version_direct():
     # This test requires packit on pythonpath
-    result = _call_packit(cli_version)
+    result = call_packit(cli_version)
     assert result.exit_code == 0
 
 
 def test_base_version():
     # This test requires packit on pythonpath
-    result = _call_packit(parameters=["version"])
+    result = call_packit(parameters=["version"])
     assert result.exit_code == 0
-    # TODO: figurate the correct version getter:
+    # TODO: figure out the correct version getter:
     # version = get_version(root="../..", relative_to=__file__)
     # name_ver = get_distribution(__name__).version
     # packit_ver = get_distribution("packit").version
@@ -45,7 +35,7 @@ def test_base_version():
 
 @pytest.mark.parametrize("cmd_function", [update, watch_releases, build, create_update])
 def test_base_subcommand_direct(cmd_function):
-    result = _call_packit(cmd_function, parameters=["--help"])
+    result = call_packit(cmd_function, parameters=["--help"])
     assert result.exit_code == 0
 
 
@@ -53,6 +43,6 @@ def test_base_subcommand_direct(cmd_function):
     "subcommand", ["propose-update", "watch-releases", "build", "create-update"]
 )
 def test_base_subcommand_help(subcommand):
-    result = _call_packit(packit_base, parameters=[subcommand, "--help"])
+    result = call_packit(packit_base, parameters=[subcommand, "--help"])
     assert result.exit_code == 0
     assert f"Usage: packit {subcommand} [OPTIONS]" in result.output


### PR DESCRIPTION
Built on top of #146 so this one is easier to review.

TODO:
* [x] merge #146
* [x] maybe resolve some TODOs/FIXMEs from the code?
* [x] skip bumpspec test on centos, the binary is too old in there: `rpmdev-bumpspec: error: no such option: --new` -- do `@pytest.mark.skipif(not bumspec_knows_new_option)`
* [x] utilize rebase-helper Spec class to change the version and implement what Franta suggested
* [x] check tito, copr and rebase-helper how they do SRPMs
  * [tito uses](https://github.com/dgoodwin/tito/blob/master/src/tito/builder/fetch.py#L117) a ton of magic code (regexes, weird ifs) and changes spec on its own, no bumpspec; [here is a code to generate srpm](https://github.com/dgoodwin/tito/blob/master/src/tito/builder/main.py#L200), I'd say our is better
  * rebase-helper has a different use case: it knows everything: spec, sources, version, so [it's trivial](https://github.com/rebase-helper/rebase-helper/blob/master/rebasehelper/srpm_build_tools/rpmbuild_tool.py) to construct the srpm for rebase-helper
  * [rdopkg uses fedpkg to create a srpm](https://github.com/softwarefactory-project/rdopkg/blob/a6e6497bfcff0ac4940b3dc28592c05d028a04d7/rdopkg/actions/distgit/actions.py#L997)
  * [copr uses mock to create SRPMs](https://pagure.io/copr/copr/blob/master/f/rpmbuild/copr_rpmbuild/builders/mock.py#_67) from its internal dist-git

If you look at the code carefully, you'll see there is a bunch of "unknown"
stuff: comments & feedback is welcome.

Fixes #122 