### PR TITLE
Helper function to get PackitAPI in CLI

### DIFF
--- a/packit/cli/build.py
+++ b/packit/cli/build.py
@@ -3,10 +3,9 @@ import os
 
 import click
 
-from packit.api import PackitAPI
 from packit.cli.types import LocalProjectParameter
-from packit.cli.utils import cover_packit_exception
-from packit.config import pass_config, get_context_settings, get_local_package_config
+from packit.cli.utils import cover_packit_exception, get_packit_api
+from packit.config import pass_config, get_context_settings
 
 logger = logging.getLogger(__file__)
 
@@ -23,10 +22,7 @@ logger = logging.getLogger(__file__)
     "Otherwise clone the repo in a temporary directory.",
 )
 @click.option(
-    "--scratch",
-    is_flag=True,
-    default=False,
-    help="Submit a scratch koji build"
+    "--scratch", is_flag=True, default=False, help="Submit a scratch koji build"
 )
 @click.argument(
     "repo", type=LocalProjectParameter(), default=os.path.abspath(os.path.curdir)
@@ -42,8 +38,5 @@ def build(config, dist_git_path, dist_git_branch, scratch, repo):
     REPO argument is a local path to the upstream git repository,
     it defaults to the current working directory
     """
-    package_config = get_local_package_config(directory=repo.working_dir)
-    package_config.downstream_project_url = dist_git_path
-    package_config.upstream_project_url = repo.working_dir
-    api = PackitAPI(config=config, package_config=package_config)
+    api = get_packit_api(config=config, dist_git_path=dist_git_path, repo=repo)
     api.build(dist_git_branch, scratch=scratch)

--- a/packit/cli/create_update.py
+++ b/packit/cli/create_update.py
@@ -3,20 +3,16 @@ import os
 
 import click
 
-from packit.api import PackitAPI
 from packit.cli.types import LocalProjectParameter
-from packit.cli.utils import cover_packit_exception
-from packit.config import pass_config, get_context_settings, get_local_package_config
+from packit.cli.utils import cover_packit_exception, get_packit_api
+from packit.config import pass_config, get_context_settings
 from packit.constants import DEFAULT_BODHI_NOTE
 
 logger = logging.getLogger(__file__)
 
 
 @click.command("create-update", context_settings=get_context_settings())
-@click.option(
-    "--dist-git-branch",
-    help="Target branch in dist-git to release into.",
-)
+@click.option("--dist-git-branch", help="Target branch in dist-git to release into.")
 @click.option(
     "--koji-build",
     help="Koji build to add to the bodhi update (can be specified multiple times)",
@@ -36,7 +32,7 @@ logger = logging.getLogger(__file__)
     type=click.types.Choice(("security", "bugfix", "enhancement", "newpackage")),
     help="Type of the bodhi update",
     required=False,
-    default="enhancement"
+    default="enhancement",
 )
 @click.argument(
     "repo", type=LocalProjectParameter(), default=os.path.abspath(os.path.curdir)
@@ -50,8 +46,10 @@ def create_update(config, dist_git_branch, koji_build, update_notes, update_type
     REPO argument is a local path to the upstream git repository,
     it defaults to the current working directory
     """
-    package_config = get_local_package_config(directory=repo.working_dir)
-    package_config.upstream_project_url = repo.working_dir
-    api = PackitAPI(config=config, package_config=package_config)
-    api.create_update(koji_builds=koji_build, dist_git_branch=dist_git_branch,
-                      update_notes=update_notes, update_type=update_type)
+    api = get_packit_api(config=config, repo=repo)
+    api.create_update(
+        koji_builds=koji_build,
+        dist_git_branch=dist_git_branch,
+        update_notes=update_notes,
+        update_type=update_type,
+    )

--- a/packit/cli/update.py
+++ b/packit/cli/update.py
@@ -7,10 +7,9 @@ import os
 
 import click
 
-from packit.api import PackitAPI
 from packit.cli.types import LocalProjectParameter
-from packit.cli.utils import cover_packit_exception
-from packit.config import pass_config, get_context_settings, get_local_package_config
+from packit.cli.utils import cover_packit_exception, get_packit_api
+from packit.config import pass_config, get_context_settings
 
 logger = logging.getLogger(__file__)
 
@@ -42,8 +41,5 @@ def update(config, dist_git_path, dist_git_branch, repo, version):
     VERSION argument is optional, the latest upstream version
     will be used by default
     """
-    package_config = get_local_package_config(directory=repo.working_dir)
-    package_config.downstream_project_url = dist_git_path
-    package_config.upstream_project_url = repo.working_dir
-    api = PackitAPI(config=config, package_config=package_config)
+    api = get_packit_api(config=config, dist_git_path=dist_git_path, repo=repo)
     api.sync_release(dist_git_branch, version=version)


### PR DESCRIPTION
- Use get_packit_api in propose-update CLI function.
- Use get_packit_api in create-update CLI function.
- Use get_packit_api in build CLI function.
- Add helper function for loading config and PackitAPI.

---

It first tries to load `package_config` from the local directory:
- it is useful when you would like to use packit without config in the repo. (Newcomers can try packit more easily.)
- Make it rather "the last choice"? (If no config can be found in the repo, try the local one.)