### PR TITLE
Allow preserving local content on propose-update

### DIFF
--- a/packit/cli/sourcegit_to_dist_git.py
+++ b/packit/cli/sourcegit_to_dist_git.py
@@ -33,10 +33,10 @@ def sg2dg(config, dest_dir, no_new_sources, upstream_ref, version, repo):
     5. The output is the directory (= dirty git repo)
     """
 
-    package_config = get_local_package_config()
+    package_config = get_local_package_config(try_local_dir_first=True)
     sourcegit = LocalProject(git_url=repo)
     if not package_config:
-        package_config = get_local_package_config(directory=sourcegit.working_dir)
+        package_config = get_local_package_config(sourcegit.working_dir)
     distgit = LocalProject(
         git_url=package_config.metadata["dist_git_url"],
         namespace="rpms",

--- a/packit/cli/sourcegit_to_srpm.py
+++ b/packit/cli/sourcegit_to_srpm.py
@@ -32,10 +32,10 @@ def sg2srpm(config, dest_dir, upstream_ref, version, repo):
     3. create SRPM
     """
 
-    package_config = get_local_package_config()
+    package_config = get_local_package_config(try_local_dir_first=True)
     sourcegit = LocalProject(git_url=repo)
     if not package_config:
-        package_config = get_local_package_config(directory=sourcegit.working_dir)
+        package_config = get_local_package_config(sourcegit.working_dir)
 
     distgit = LocalProject(
         git_url=package_config.metadata["dist_git_url"],

--- a/packit/cli/update.py
+++ b/packit/cli/update.py
@@ -25,13 +25,19 @@ logger = logging.getLogger(__file__)
     help="Path to dist-git repo to work in. "
     "Otherwise clone the repo in a temporary directory.",
 )
+@click.option(
+    "--local-content",
+    is_flag=True,
+    default=False,
+    help="Do not checkout release tag. Use the current state of the repo.",
+)
 @click.argument(
     "repo", type=LocalProjectParameter(), default=os.path.abspath(os.path.curdir)
 )
 @click.argument("version", required=False)
 @pass_config
 @cover_packit_exception
-def update(config, dist_git_path, dist_git_branch, repo, version):
+def update(config, dist_git_path, dist_git_branch, local_content, repo, version):
     """
     Release current upstream release into Fedora
 
@@ -42,4 +48,4 @@ def update(config, dist_git_path, dist_git_branch, repo, version):
     will be used by default
     """
     api = get_packit_api(config=config, dist_git_path=dist_git_path, repo=repo)
-    api.sync_release(dist_git_branch, version=version)
+    api.sync_release(dist_git_branch, use_local_content=local_content, version=version)

--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -70,13 +70,7 @@ def get_packit_api(config: Config, repo: LocalProject, dist_git_path: str = None
     """
     Load the package config, set other options and return the PackitAPI
     """
-    package_config = get_local_package_config()
-    if (
-        not package_config
-        and repo.working_dir
-        and repo.working_dir != os.path.abspath(os.path.curdir)
-    ):
-        package_config = get_local_package_config(directory=repo.working_dir)
+    package_config = get_local_package_config(repo.working_dir, try_local_dir_first=True)
 
     if dist_git_path:
         package_config.downstream_project_url = dist_git_path

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -31,7 +31,7 @@ class Upstream:
 
     @property
     def active_branch(self):
-        return self.local_project.git_repo.active_branch
+        return self.local_project.ref
 
     @property
     def specfile_path(self) -> Optional[str]:


### PR DESCRIPTION
- Add local-content option to propose-update. (off by default)
- Allow using local-content in release-update.
- Fix non-branch ref in upstream.
- Correct calls of get_local_package_config.
- Allow *args in get_local_package_config.

----

You can now use following worflow:

```bash
git clone https://my.best/repo.git
cd repo
g checkout 0.1.0

# make changes
# (e.g. add .packit.yaml or repo.spec)

packit propose-update --local-content
```