### PR TITLE
new-sources fixes

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -147,13 +147,9 @@ class PackitAPI:
             ):
                 make_new_sources = True
             else:
-                sources_file = Path(distgit.local_project.working_dir) / Path("sources")
-                with open(str(sources_file), mode="r") as sources_file_obj:
-                    if (
-                        distgit.upstream_archive_name not
-                        in sources_file_obj.read()
-                    ):
-                        make_new_sources = True
+                sources_file = Path(distgit.local_project.working_dir) / "sources"
+                if distgit.upstream_archive_name not in sources_file.read_text():
+                    make_new_sources = True
 
             if make_new_sources:
                 archive = distgit.download_upstream_archive()

--- a/packit/api.py
+++ b/packit/api.py
@@ -3,6 +3,7 @@ This is the official python interface for packit.
 """
 
 import logging
+from pathlib import Path
 from typing import Sequence
 
 from packit.config import Config, PackageConfig
@@ -136,11 +137,25 @@ class PackitAPI:
     ):
 
         if add_new_sources or force_new_sources:
+
+            make_new_sources = False
+
             # btw this is really naive: the name could be the same but the hash can be different
             # TODO: we should do something when such situation happens
             if force_new_sources or not distgit.is_archive_in_lookaside_cache(
                 distgit.upstream_archive_name
             ):
+                make_new_sources = True
+            else:
+                sources_file = Path(distgit.local_project.working_dir) / Path("sources")
+                with open(str(sources_file), mode="r") as sources_file_obj:
+                    if (
+                        distgit.upstream_archive_name not
+                        in sources_file_obj.read()
+                    ):
+                        make_new_sources = True
+
+            if make_new_sources:
                 archive = distgit.download_upstream_archive()
                 distgit.upload_to_lookaside_cache(archive)
 

--- a/packit/api.py
+++ b/packit/api.py
@@ -59,7 +59,11 @@ class PackitAPI:
         )
 
     def sync_release(
-        self, dist_git_branch: str, use_local_content=False, version: str = None
+        self,
+        dist_git_branch: str,
+        use_local_content=False,
+        version: str = None,
+        force_new_sources=False,
     ):
         """
         Update given package in Fedora
@@ -113,6 +117,7 @@ class PackitAPI:
                 dist_git_branch=dist_git_branch,
                 commit_msg_description=description,
                 add_new_sources=True,
+                force_new_sources=force_new_sources,
             )
         finally:
             if not use_local_content:
@@ -127,12 +132,15 @@ class PackitAPI:
         dist_git_branch: str,
         commit_msg_description: str = None,
         add_new_sources=False,
+        force_new_sources=False,
     ):
 
-        if add_new_sources:
+        if add_new_sources or force_new_sources:
             # btw this is really naive: the name could be the same but the hash can be different
             # TODO: we should do something when such situation happens
-            if not distgit.is_archive_in_lookaside_cache(distgit.upstream_archive_name):
+            if force_new_sources or not distgit.is_archive_in_lookaside_cache(
+                distgit.upstream_archive_name
+            ):
                 archive = distgit.download_upstream_archive()
                 distgit.upload_to_lookaside_cache(archive)
 

--- a/packit/cli/update.py
+++ b/packit/cli/update.py
@@ -31,13 +31,27 @@ logger = logging.getLogger(__file__)
     default=False,
     help="Do not checkout release tag. Use the current state of the repo.",
 )
+@click.option(
+    "--force-new-sources",
+    is_flag=True,
+    default=False,
+    help="Upload the new sources also when the archive is already in the lookaside cache.",
+)
 @click.argument(
     "repo", type=LocalProjectParameter(), default=os.path.abspath(os.path.curdir)
 )
 @click.argument("version", required=False)
 @pass_config
 @cover_packit_exception
-def update(config, dist_git_path, dist_git_branch, local_content, repo, version):
+def update(
+    config,
+    dist_git_path,
+    dist_git_branch,
+    force_new_sources,
+    local_content,
+    repo,
+    version,
+):
     """
     Release current upstream release into Fedora
 
@@ -48,4 +62,9 @@ def update(config, dist_git_path, dist_git_branch, local_content, repo, version)
     will be used by default
     """
     api = get_packit_api(config=config, dist_git_path=dist_git_path, repo=repo)
-    api.sync_release(dist_git_branch, use_local_content=local_content, version=version)
+    api.sync_release(
+        dist_git_branch,
+        use_local_content=local_content,
+        version=version,
+        force_new_sources=force_new_sources,
+    )


### PR DESCRIPTION
- Upload new-sources if we have old sources files.
- Add --force-new-sources option to propose-update.
- Add --force-new-sources option to sync_release.


Resolves: #161 