### PR TITLE
Better bodhi output

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -407,10 +407,20 @@ class DistGit:
         rendered_note = update_notes.format(version=self.specfile.get_full_version())
         try:
             result = b.save(builds=koji_builds, notes=rendered_note, type=update_type)
-            logger.info(f"Bodhi response:\n{result}")
+            logger.debug(f"Bodhi response:\n{result}")
+            logger.info(
+                f"Bodhi update {result['alias']}:\n"
+                f"- {result['url']}\n"
+                f"- autokarma: {result['autokarma']}\n"
+                f"- stable_karma: {result['stable_karma']}\n"
+                f"- unstable_karma: {result['unstable_karma']}"
+            )
+            for cav in result["caveats"]:
+                logger.info(f"- {cav['name']}: {cav['description']}\n")
+
         except BodhiClientException as ex:
             logger.error(ex)
             raise PackitException(
                 f"There is a problem with creating the bodhi update:\n{ex}"
             )
-        return result
+        return result["alias"]

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -411,9 +411,9 @@ class DistGit:
             logger.info(
                 f"Bodhi update {result['alias']}:\n"
                 f"- {result['url']}\n"
-                f"- autokarma: {result['autokarma']}\n"
                 f"- stable_karma: {result['stable_karma']}\n"
                 f"- unstable_karma: {result['unstable_karma']}"
+                f"- notes:\n{result['notes']}\n"
             )
             for cav in result["caveats"]:
                 logger.info(f"- {cav['name']}: {cav['description']}\n")


### PR DESCRIPTION
```
Bodhi update FEDORA-2019-b72add0dcd:
- https://bodhi.fedoraproject.org/updates/FEDORA-2019-b72add0dcd
- autokarma: True
- stable_karma: 3
- unstable_karma: -3
```

#### Bodhi response

```

            Munch({'title': 'packit-0.1.0-1.fc30', 'autokarma': True, 'stable_karma': 3, 'unstable_karma': -3, 'requirements': '', 'require_bugs': True, 'require_testcases': True, 'display_name': '', 'notes': 'New upstream release: 0.1.0\n\n----\n\nInitial version: 0.0.1', 'type': 'enhancement', 'status': 'pending', 'request': 'testing', 'severity': 'unspecified', 'suggest': 'unspecified', 'locked': False, 'pushed': False, 'critpath': False, 'close_bugs': True, 'date_submitted': '2019-03-15 09:52:51', 'date_modified': None, 'date_approved': None, 'date_pushed': None, 'date_testing': None, 'date_stable': None, 'alias': 'FEDORA-2019-23c4fcee0f', 'old_updateid': None, 'test_gating_status': 'waiting', 'greenwave_summary_string': None, 'greenwave_unsatisfied_requirements': None, 'meets_testing_requirements': False, 'url': 'https://bodhi.fedoraproject.org/updates/FEDORA-2019-23c4fcee0f', 'release': Munch({'name': 'F30', 'long_name': 'Fedora 30', 'version': '30', 'id_prefix': 'FEDORA', 'branch': 'f30', 'dist_tag': 'f30', 'stable_tag': 'f30-updates', 'testing_tag': 'f30-updates-testing', 'candidate_tag': 'f30-updates-candidate', 'pending_signing_tag': 'f30-signing-pending', 'pending_testing_tag': 'f30-updates-testing-pending', 'pending_stable_tag': 'f30-updates-pending', 'override_tag': 'f30-override', 'mail_template': 'fedora_errata_template', 'state': 'pending', 'composed_by_bodhi': True, 'composes': []}), 'comments': [Munch({'id': 908906, 'karma': 0, 'karma_critpath': 0, 'text': 'This update has been submitted for testing by lachmanfrantisek. ', 'anonymous': False, 'timestamp': '2019-03-15 09:52:51', 'update_id': 133837, 'user_id': 91, 'bug_feedback': [], 'testcase_feedback': [], 'user': Munch({'id': 91, 'name': 'bodhi', 'email': None, 'show_popups': True, 'avatar': None, 'openid': None, 'groups': []})}), Munch({'id': 908908, 'karma': 0, 'karma_critpath': 0, 'text': 'This update has obsoleted [packit-0.0.1-1.fc30](https://bodhi.fedoraproject.org/updates/FEDORA-2019-f6245f75fd), and has inherited its bugs and notes.', 'anonymous': False, 'timestamp': '2019-03-15 09:52:53', 'update_id': 133837, 'user_id': 91, 'bug_feedback': [], 'testcase_feedback': [], 'user': Munch({'id': 91, 'name': 'bodhi', 'email': None, 'show_popups': True, 'avatar': None, 'openid': None, 'groups': []})})], 'builds': [Munch({'nvr': 'packit-0.1.0-1.fc30', 'release_id': 28, 'signed': False, 'ci_url': None, 'type': 'rpm', 'epoch': 0})], 'compose': None, 'bugs': [], 'user': Munch({'id': 4222, 'name': 'lachmanfrantisek', 'email': 'lachmanfrantisek@gmail.com', 'show_popups': True, 'avatar': None, 'openid': None, 'groups': [Munch({'name': 'packager'})]}), 'updateid': 'FEDORA-2019-23c4fcee0f', 'submitter': 'lachmanfrantisek', 'karma': 0, 'content_type': 'rpm', 'test_cases': [], 'caveats': [Munch({'name': 'update', 'description': 'This update has obsoleted packit-0.0.1-1.fc30, and has inherited its bugs and notes.'})]})
```
```
            a = {
                "title": "packit-0.1.0-1.fc30",
                "autokarma": True,
                "stable_karma": 3,
                "unstable_karma": -3,
                "requirements": "",
                "require_bugs": True,
                "require_testcases": True,
                "display_name": "",
                "notes": "New upstream release: 0.1.0\n\n----\n\nInitial version: 0.0.1",
                "type": "enhancement",
                "status": "pending",
                "request": "testing",
                "severity": "unspecified",
                "suggest": "unspecified",
                "locked": False,
                "pushed": False,
                "critpath": False,
                "close_bugs": True,
                "date_submitted": "2019-03-15 09:52:51",
                "date_modified": None,
                "date_approved": None,
                "date_pushed": None,
                "date_testing": None,
                "date_stable": None,
                "alias": "FEDORA-2019-23c4fcee0f",
                "old_updateid": None,
                "test_gating_status": "waiting",
                "greenwave_summary_string": None,
                "greenwave_unsatisfied_requirements": None,
                "meets_testing_requirements": False,
                "url": "https://bodhi.fedoraproject.org/updates/FEDORA-2019-23c4fcee0f",
                "release": {
                    "name": "F30",
                    "long_name": "Fedora 30",
                    "version": "30",
                    "id_prefix": "FEDORA",
                    "branch": "f30",
                    "dist_tag": "f30",
                    "stable_tag": "f30-updates",
                    "testing_tag": "f30-updates-testing",
                    "candidate_tag": "f30-updates-candidate",
                    "pending_signing_tag": "f30-signing-pending",
                    "pending_testing_tag": "f30-updates-testing-pending",
                    "pending_stable_tag": "f30-updates-pending",
                    "override_tag": "f30-override",
                    "mail_template": "fedora_errata_template",
                    "state": "pending",
                    "composed_by_bodhi": True,
                    "composes": [],
                },
                "comments": [
                    {
                        "id": 908_906,
                        "karma": 0,
                        "karma_critpath": 0,
                        "text": "This update has been submitted for testing by lachmanfrantisek. ",
                        "anonymous": False,
                        "timestamp": "2019-03-15 09:52:51",
                        "update_id": 133_837,
                        "user_id": 91,
                        "bug_feedback": [],
                        "testcase_feedback": [],
                        "user": {
                            "id": 91,
                            "name": "bodhi",
                            "email": None,
                            "show_popups": True,
                            "avatar": None,
                            "openid": None,
                            "groups": [],
                        },
                    },
                    {
                        "id": 908_908,
                        "karma": 0,
                        "karma_critpath": 0,
                        "text": "This update has obsoleted [packit-0.0.1-1.fc30](https://bodhi.fedoraproject.org/updates/FEDORA-2019-f6245f75fd), and has inherited its bugs and notes.",
                        "anonymous": False,
                        "timestamp": "2019-03-15 09:52:53",
                        "update_id": 133_837,
                        "user_id": 91,
                        "bug_feedback": [],
                        "testcase_feedback": [],
                        "user": {
                            "id": 91,
                            "name": "bodhi",
                            "email": None,
                            "show_popups": True,
                            "avatar": None,
                            "openid": None,
                            "groups": [],
                        },
                    },
                ],
                "builds": [
                    {
                        "nvr": "packit-0.1.0-1.fc30",
                        "release_id": 28,
                        "signed": False,
                        "ci_url": None,
                        "type": "rpm",
                        "epoch": 0,
                    }
                ],
                "compose": None,
                "bugs": [],
                "user": {
                    "id": 4222,
                    "name": "lachmanfrantisek",
                    "email": "lachmanfrantisek@gmail.com",
                    "show_popups": True,
                    "avatar": None,
                    "openid": None,
                    "groups": [{"name": "packager"}],
                },
                "updateid": "FEDORA-2019-23c4fcee0f",
                "submitter": "lachmanfrantisek",
                "karma": 0,
                "content_type": "rpm",
                "test_cases": [],
                "caveats": [
                    {
                        "name": "update",
                        "description": "This update has obsoleted packit-0.0.1-1.fc30, and has inherited its bugs and notes.",
                    }
                ],
            }
```