### PR TITLE
recipe: set metadata in the playbook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
-BASE_IMAGE := registry.fedoraproject.org/fedora:29
 TEST_TARGET := ./tests/
 PY_PACKAGE := packit
 SOURCE_GIT_IMAGE := packit
 PACKIT_TESTS_IMAGE := packit-tests
 
 build: recipe.yaml
-	ansible-bender build --build-volumes $(CURDIR):/src:Z -- ./recipe.yaml $(BASE_IMAGE) $(SOURCE_GIT_IMAGE)
+	ansible-bender build -- ./recipe.yaml
 
 prepare-check:
 	ansible-playbook -b -K -i inventory-local -c local ./recipe-tests.yaml

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,6 +1,14 @@
 ---
 - name: This is a recipe for how to cook with packit
   hosts: all
+  vars:
+    ansible_bender:
+      target_image:
+        name: packit
+      working_container:
+        volumes:
+        - '{{ playbook_dir }}:/src:Z'
+      base_image: fedora:29
   tasks:
   - name: Install all packages needed to hack on packit.
     dnf:


### PR DESCRIPTION
```
PLAY RECAP ******************************************************************************************************************************************************************
packit-20190322-142125055598-cont : ok=12   changed=9    unreachable=0    failed=0

Getting image source signatures
Copying blob sha256:97b94d418dac4ec6da11f188c162831ddf674b08c496d1fd9ebaf5d497f94e08
Copying blob sha256:3f4f2e0cf35341ceb2100eeddb7d14f35cbd3043334048f11d9e18635700c9a4
Copying config sha256:7cdd0871485af8f0b838de92590e05ed0d58965e9764e9c7b5d0251a2fee22ee                                                                                      
Writing manifest to image destination
Storing signatures
7cdd0871485af8f0b838de92590e05ed0d58965e9764e9c7b5d0251a2fee22ee
Image 'packit' was built successfully \o/
```