### PR TITLE
Support copying of directories

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,9 +52,7 @@ upstream_project_name: packitos
 downstream_package_name: packit
 ```
 
-
 ### Real examples
-
 
 The list of projects which already have packit config in their upstream repositories:
 * [packit-service/packit](https://github.com/packit-service/packit/blob/master/.packit.yaml)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,13 +34,27 @@ This is a sample config which is meant for packit itself.
 ```yaml
 specfile_path: packit.spec
 synced_files:
+# possible styles how to write a file to sync
+  # Copy the file in an upstream directory into the same downstream directory.
+  # File name is not changed
   - packit.spec
+  # src means a source file in root from the upstream directory.
+  # dest means a directory and filename into the downstream directory.
+  # in this case the name is the same
+  - src: packit.spec
+    dest: redhat/packit.spec
+  # src means all md files in a root from the upstream directory
+  # dest means all md files are copied into the downstream docs directory.
+  - src: *.md
+    dest: docs/
 # packit was already taken on PyPI
 upstream_project_name: packitos
 downstream_package_name: packit
 ```
 
+
 ### Real examples
+
 
 The list of projects which already have packit config in their upstream repositories:
 * [packit-service/packit](https://github.com/packit-service/packit/blob/master/.packit.yaml)

--- a/packit/api.py
+++ b/packit/api.py
@@ -69,7 +69,7 @@ class PackitAPI:
         self._handle_sources(add_new_sources=True, force_new_sources=False)
 
         sync_files(
-            self.up.files_to_sync,
+            self.package_config,
             self.up.local_project.working_dir,
             self.dg.local_project.working_dir,
         )
@@ -134,7 +134,11 @@ class PackitAPI:
             )
 
             if self.package_config.with_action(action_name="prepare-files"):
-                self.dg.sync_files(self.up.local_project)
+                sync_files(
+                    self.package_config,
+                    self.up.local_project.working_dir,
+                    self.dg.local_project.working_dir,
+                )
                 if upstream_ref:
                     if self.package_config.with_action(action_name="patch"):
                         patches = self.up.create_patches(
@@ -149,7 +153,7 @@ class PackitAPI:
 
             if self.package_config.has_action("prepare-files"):
                 sync_files(
-                    self.up.files_to_sync,
+                    self.package_config,
                     self.up.local_project.working_dir,
                     self.dg.local_project.working_dir,
                 )
@@ -196,7 +200,7 @@ class PackitAPI:
         self.up.checkout_branch(local_pr_branch)
 
         sync_files(
-            self.up.files_to_sync,
+            self.package_config,
             self.dg.local_project.working_dir,
             self.up.local_project.working_dir,
         )

--- a/packit/api.py
+++ b/packit/api.py
@@ -12,6 +12,7 @@ from packit.exceptions import PackitException
 from packit.status import Status
 from packit.upstream import Upstream
 from packit.utils import assert_existence
+from packit.sync import sync_files
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +68,11 @@ class PackitAPI:
 
         self._handle_sources(add_new_sources=True, force_new_sources=False)
 
-        self.dg.sync_files(upstream_project=self.up.local_project)
+        sync_files(
+            self.up.files_to_sync,
+            self.up.local_project.working_dir,
+            self.dg.local_project.working_dir,
+        )
         self.dg.commit(title=f"Sync upstream pr: {pr_id}", msg=description)
 
         self.push_and_create_pr(
@@ -143,7 +148,11 @@ class PackitAPI:
                 )
 
             if self.package_config.has_action("prepare-files"):
-                self.dg.sync_files(self.up.local_project)
+                sync_files(
+                    self.up.files_to_sync,
+                    self.up.local_project.working_dir,
+                    self.dg.local_project.working_dir,
+                )
 
             self.dg.commit(title=f"{full_version} upstream release", msg=description)
 
@@ -186,7 +195,11 @@ class PackitAPI:
         self.up.create_branch(local_pr_branch)
         self.up.checkout_branch(local_pr_branch)
 
-        self.up.sync_files(self.dg.local_project)
+        sync_files(
+            self.up.files_to_sync,
+            self.dg.local_project.working_dir,
+            self.up.local_project.working_dir,
+        )
 
         if not no_pr:
             description = (

--- a/packit/config.py
+++ b/packit/config.py
@@ -183,6 +183,23 @@ class SyncFilesConfig:
     def is_dict_valid(cls, raw_dict: dict) -> bool:
         return Draft4Validator(SYNCED_FILES_SCHEMA).is_valid(raw_dict)
 
+    def __eq__(self, other: object):
+        if not isinstance(other, SyncFilesConfig):
+            return NotImplemented
+
+        if not self.files_to_sync and not other.files_to_sync:
+            return True
+
+        if len(self.files_to_sync) != len(other.files_to_sync):
+            return False
+        compare = False
+        for f in self.files_to_sync:
+            for o in other.files_to_sync:
+                if f.src == o.src and f.dest == o.dest:
+                    compare = True
+
+        return compare
+
 
 class PackageConfig:
     """
@@ -206,7 +223,7 @@ class PackageConfig:
         actions: Dict[str, str] = None,
     ):
         self.specfile_path: Optional[str] = specfile_path
-        self.synced_files: Optional[SyncFilesConfig] = synced_files or []
+        self.synced_files: Optional[SyncFilesConfig] = synced_files or None
         self.jobs: List[JobConfig] = jobs or []
         self.dist_git_namespace: str = dist_git_namespace or "rpms"
         self.upstream_project_url: Optional[str] = upstream_project_url

--- a/packit/config.py
+++ b/packit/config.py
@@ -156,6 +156,14 @@ class SyncFilesItem(NamedTuple):
     src: str
     dest: str
 
+    def __eq__(self, other: object):
+        if not isinstance(other, SyncFilesItem):
+            return NotImplemented
+
+        if self.src == other.src and self.dest == other.dest:
+            return True
+        return False
+
 
 class SyncFilesConfig:
     def __init__(self, files_to_sync: List[SyncFilesItem]):
@@ -192,13 +200,10 @@ class SyncFilesConfig:
 
         if len(self.files_to_sync) != len(other.files_to_sync):
             return False
-        compare = False
-        for f in self.files_to_sync:
-            for o in other.files_to_sync:
-                if f.src == o.src and f.dest == o.dest:
-                    compare = True
 
-        return compare
+        if self.files_to_sync == other.files_to_sync:
+            return True
+        return False
 
 
 class PackageConfig:

--- a/packit/config.py
+++ b/packit/config.py
@@ -4,6 +4,7 @@ import os
 from enum import IntEnum
 from functools import lru_cache
 from pathlib import Path
+
 from typing import Optional, List, NamedTuple, Dict, Callable
 
 import click
@@ -151,6 +152,38 @@ class JobConfig(NamedTuple):
         return Draft4Validator(JOB_CONFIG_SCHEMA).is_valid(raw_dict)
 
 
+class SyncFilesItem(NamedTuple):
+    src: str
+    dest: str
+
+
+class SyncFilesConfig:
+    def __init__(self, files_to_sync: List[SyncFilesItem]):
+        self.files_to_sync = files_to_sync
+
+    @classmethod
+    def get_from_dict(cls, raw_dict: dict, validate=True) -> "SyncFilesConfig":
+        if validate and not SyncFilesConfig.is_dict_valid(raw_dict):
+            raise Exception(f"Sync files config not valid.")
+
+        files_to_sync = []
+        if isinstance(raw_dict, list):
+            for f in raw_dict:
+                if isinstance(f, dict):
+                    files_to_sync.append(SyncFilesItem(src=f["src"], dest=f["dest"]))
+                else:
+                    files_to_sync.append(SyncFilesItem(src=f, dest=f))
+        if isinstance(raw_dict, dict):
+            for f in raw_dict:
+                files_to_sync.append(SyncFilesItem(src=f["src"], dest=f["dest"]))
+
+        return SyncFilesConfig(files_to_sync=files_to_sync)
+
+    @classmethod
+    def is_dict_valid(cls, raw_dict: dict) -> bool:
+        return Draft4Validator(SYNCED_FILES_SCHEMA).is_valid(raw_dict)
+
+
 class PackageConfig:
     """
     Config class for upstream/downstream packages;
@@ -160,7 +193,7 @@ class PackageConfig:
     def __init__(
         self,
         specfile_path: Optional[str] = None,
-        synced_files: Optional[List[str]] = None,
+        synced_files: Optional[SyncFilesConfig] = None,
         jobs: Optional[List[JobConfig]] = None,
         dist_git_namespace: str = None,
         upstream_project_url: str = None,  # can be URL or path
@@ -173,7 +206,7 @@ class PackageConfig:
         actions: Dict[str, str] = None,
     ):
         self.specfile_path: Optional[str] = specfile_path
-        self.synced_files: List[str] = synced_files or []
+        self.synced_files: Optional[SyncFilesConfig] = synced_files or []
         self.jobs: List[JobConfig] = jobs or []
         self.dist_git_namespace: str = dist_git_namespace or "rpms"
         self.upstream_project_url: Optional[str] = upstream_project_url
@@ -256,10 +289,9 @@ class PackageConfig:
 
         dist_git_base_url = raw_dict.get("dist_git_base_url", None)
         dist_git_namespace = raw_dict.get("dist_git_namespace", None)
-
         pc = PackageConfig(
             specfile_path=specfile_path,
-            synced_files=synced_files,
+            synced_files=SyncFilesConfig.get_from_dict(synced_files, validate=False),
             actions=actions,
             jobs=[
                 JobConfig.get_from_dict(raw_job, validate=False) for raw_job in raw_jobs
@@ -272,7 +304,6 @@ class PackageConfig:
             create_tarball_command=create_tarball_command,
             current_version_command=current_version_command,
         )
-
         return pc
 
     @staticmethod
@@ -459,6 +490,16 @@ JOB_CONFIG_SCHEMA = {
     "required": ["trigger", "release_to"],
 }
 
+SYNCED_FILES_SCHEMA = {
+    "anyOf": [
+        {"type": "string"},
+        {
+            "type": "object",
+            "properties": {"src": {"type": "string"}, "dest": {"type": "string"}},
+        },
+    ]
+}
+
 PACKAGE_CONFIG_SCHEMA = {
     "type": "object",
     "properties": {
@@ -467,7 +508,7 @@ PACKAGE_CONFIG_SCHEMA = {
         "upstream_project_name": {"type": "string"},
         "create_tarball_command": {"type": "array", "items": {"type": "string"}},
         "current_version_command": {"type": "array", "items": {"type": "string"}},
-        "synced_files": {"type": "array", "items": {"type": "string"}},
+        "synced_files": {"type": "array", "items": SYNCED_FILES_SCHEMA},
         "jobs": {"type": "array", "items": JOB_CONFIG_SCHEMA},
         "actions": {"type": "object", "additionalProperties": {"type": "string"}},
     },

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -247,7 +247,6 @@ class DistGit(PackitRepositoryBase):
         # TODO: remove branches from merged PRs
         raise NotImplementedError("not implemented yet")
 
-
     def add_patches_to_specfile(self, patch_list: List[Tuple[str, str]]) -> None:
         """
         Add the given list of (patch_name, msg) to the specfile.

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import shutil
 from typing import Optional, List, Tuple, Sequence
 
 import git
@@ -8,7 +7,7 @@ import requests
 from rebasehelper.specfile import SpecFile
 
 from ogr.services.pagure import PagureService
-from packit.config import Config, PackageConfig
+from packit.config import Config, PackageConfig, SyncFilesConfig
 from packit.exceptions import PackitException
 from packit.local_project import LocalProject
 
@@ -44,7 +43,7 @@ class DistGit(PackitRepositoryBase):
         self.fas_user = self.config.fas_user
         self.dist_git_url: str = self.package_config.downstream_project_url
         logger.debug(f"Using dist-git repo {self.dist_git_url}")
-        self.files_to_sync: List[str] = self.package_config.synced_files
+        self.files_to_sync: Optional[SyncFilesConfig] = self.package_config.synced_files
         self.dist_git_namespace: str = self.package_config.dist_git_namespace
         self._specfile = None
 
@@ -248,24 +247,6 @@ class DistGit(PackitRepositoryBase):
         # TODO: remove branches from merged PRs
         raise NotImplementedError("not implemented yet")
 
-    def sync_files(self, upstream_project: LocalProject) -> None:
-        """
-        Sync required files from upstream to downstream.
-        """
-        logger.debug(f"About to sync files {self.files_to_sync}")
-        if self.package_config.with_action(action_name="sync-up-to-down"):
-            for fi in self.files_to_sync:
-                # TODO: fi can be dir
-                fi = fi[1:] if fi.startswith("/") else fi
-                src = os.path.join(upstream_project.working_dir, fi)
-                if os.path.exists(src):
-                    logger.info(f"Syncing {src}")
-                    shutil.copy2(src, self.local_project.working_dir)
-                else:
-                    raise PackitException(
-                        f"File {fi} is not present in the upstream repository. "
-                        f"Upstream ref {upstream_project.git_repo.head} is checked out"
-                    )
 
     def add_patches_to_specfile(self, patch_list: List[Tuple[str, str]]) -> None:
         """

--- a/packit/sync.py
+++ b/packit/sync.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_wildcard_resolved_sync_files(pc: PackageConfig) -> None:
-    logger.debug("Packit synced files %s", pc.synced_files)
+    logger.debug("Packit synced files %s", pc.synced_files.files_to_sync)
     files_to_sync = []
     for sync in pc.synced_files.files_to_sync:
         if isinstance(sync, str):
@@ -29,18 +29,19 @@ def sync_files(pc: PackageConfig, src_working_dir: str, dest_working_dir: str) -
     Sync required files from upstream to downstream.
     """
     get_wildcard_resolved_sync_files(pc)
-    logger.debug(f"Copy synced files {pc.synced_files}")
+    logger.debug(f"Copy synced files {pc.synced_files.files_to_sync}")
     for fi in pc.synced_files.files_to_sync:
         # Check if destination dir exists
         # If not create the destination dir
         dest_dir = os.path.join(dest_working_dir, fi.dest)
+        logger.debug(f"Destination {dest_dir}")
         # Sync all source file
-        for src in fi.src:
-            src_file = os.path.join(src_working_dir, src)
-            if os.path.exists(src_file):
-                logger.info(f"Syncing {src}")
-                shutil.copy2(src_file, dest_dir)
-            else:
-                raise PackitException(
-                    f"File {src_file} is not present in the upstream repository. "
-                )
+        src_file = os.path.join(src_working_dir, fi.src)
+        logger.debug(f"Source file {src_file}")
+        if os.path.exists(src_file):
+            logger.info(f"Syncing {src_file}")
+            shutil.copy2(src_file, dest_dir)
+        else:
+            raise PackitException(
+                f"File {src_file} is not present in the upstream repository. "
+            )

--- a/packit/sync.py
+++ b/packit/sync.py
@@ -13,10 +13,15 @@ def get_wildcard_resolved_sync_files(pc: PackageConfig) -> None:
     logger.debug("Packit synced files %s", pc.synced_files.files_to_sync)
     files_to_sync = []
     for sync in pc.synced_files.files_to_sync:
-        if isinstance(sync, str):
-            files_to_sync.append(SyncFilesItem(src=sync, dest=sync))
-            continue
-        src = glob.glob(sync.src)
+        source = sync.src
+        if isinstance(source, str):
+            if "*" not in source:
+                if source.endswith("/"):
+                    source = f"{source}*"
+                else:
+                    files_to_sync.append(SyncFilesItem(src=source, dest=sync.dest))
+                    continue
+        src = glob.glob(source)
         if src:
             for s in src:
                 files_to_sync.append(SyncFilesItem(src=s, dest=sync.dest))

--- a/packit/sync.py
+++ b/packit/sync.py
@@ -1,0 +1,46 @@
+import glob
+import os
+import shutil
+import logging
+
+from packit.exceptions import PackitException
+from packit.config import PackageConfig, SyncFilesItem, SyncFilesConfig
+
+logger = logging.getLogger(__name__)
+
+
+def get_wildcard_resolved_sync_files(pc: PackageConfig) -> None:
+    logger.debug("Packit synced files %s", pc.synced_files)
+    files_to_sync = []
+    for sync in pc.synced_files.files_to_sync:
+        if isinstance(sync, str):
+            files_to_sync.append(SyncFilesItem(src=sync, dest=sync))
+            continue
+        src = glob.glob(sync.src)
+        if src:
+            for s in src:
+                files_to_sync.append(SyncFilesItem(src=s, dest=sync.dest))
+    logger.debug(f"Resolved synced file {files_to_sync}")
+    pc.synced_files = SyncFilesConfig(files_to_sync=files_to_sync)
+
+
+def sync_files(pc: PackageConfig, src_working_dir: str, dest_working_dir: str) -> None:
+    """
+    Sync required files from upstream to downstream.
+    """
+    get_wildcard_resolved_sync_files(pc)
+    logger.debug(f"Copy synced files {pc.synced_files}")
+    for fi in pc.synced_files.files_to_sync:
+        # Check if destination dir exists
+        # If not create the destination dir
+        dest_dir = os.path.join(dest_working_dir, fi.dest)
+        # Sync all source file
+        for src in fi.src:
+            src_file = os.path.join(src_working_dir, src)
+            if os.path.exists(src_file):
+                logger.info(f"Syncing {src}")
+                shutil.copy2(src_file, dest_dir)
+            else:
+                raise PackitException(
+                    f"File {src_file} is not present in the upstream repository. "
+                )

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -1,10 +1,9 @@
 import logging
 import os
 import re
-import shutil
 from pathlib import Path
 from typing import Optional, List, Tuple
-from packaging import _version
+from packaging import version
 
 import git
 import github
@@ -13,8 +12,6 @@ from rebasehelper.exceptions import RebaseHelperError
 from rebasehelper.specfile import SpecFile
 from rebasehelper.versioneer import versioneers_runner
 
-from packit.config import Config, PackageConfig
-from ogr.services.github import GithubService
 from packit.config import Config, PackageConfig, SyncFilesConfig
 from packit.exceptions import PackitException
 from packit.local_project import LocalProject

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -4,7 +4,7 @@ import re
 import shutil
 from pathlib import Path
 from typing import Optional, List, Tuple
-from packaging import version
+from packaging import _version
 
 import git
 import github
@@ -14,6 +14,8 @@ from rebasehelper.specfile import SpecFile
 from rebasehelper.versioneer import versioneers_runner
 
 from packit.config import Config, PackageConfig
+from ogr.services.github import GithubService
+from packit.config import Config, PackageConfig, SyncFilesConfig
 from packit.exceptions import PackitException
 from packit.local_project import LocalProject
 from packit.utils import run_command
@@ -35,7 +37,7 @@ class Upstream(PackitRepositoryBase):
 
         self.github_token = self.config.github_token
         self.upstream_project_url: str = self.package_config.upstream_project_url
-        self.files_to_sync: Optional[List[str]] = self.package_config.synced_files
+        self.files_to_sync: Optional[SyncFilesConfig] = self.package_config.synced_files
 
     @property
     def active_branch(self):
@@ -309,25 +311,6 @@ class Upstream(PackitRepositoryBase):
         version = self.specfile.get_version()
         logger.info(f"Version in spec file is {version!r}.")
         return version
-
-    def sync_files(self, downstream_project: LocalProject) -> None:
-        """
-        sync required files from downstream to upstream
-        """
-        logger.debug("about to sync files %s", self.files_to_sync)
-        if self.package_config.with_action(action_name="sync-down-to-up"):
-            for fi in self.files_to_sync:
-                # TODO: fi can be dir
-                fi = fi[1:] if fi.startswith("/") else fi
-                src = os.path.join(downstream_project.working_dir, fi)
-                if os.path.exists(src):
-                    logger.info("syncing %s", src)
-                    shutil.copy2(src, self.local_project.working_dir)
-                else:
-                    raise PackitException(
-                        f"File {src} is not present in the downstream repository. "
-                        f"Upstream ref {downstream_project.git_repo.active_branch} is checked out"
-                    )
 
     def get_version(self) -> str:
         """

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -574,6 +574,15 @@ def test_get_user_config(tmpdir):
             ],
         ),
         (
+            SyncFilesConfig(
+                files_to_sync=[SyncFilesItem(src="functional/", dest="tests")]
+            ),
+            [
+                {"src": "functional/__init__.py", "dest": "tests"},
+                {"src": "functional/test_srpm.py", "dest": "tests"},
+            ],
+        ),
+        (
             SyncFilesConfig(files_to_sync=[SyncFilesItem(src="*.py", dest="tests")]),
             [
                 {"src": "__init__.py", "dest": "tests"},

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,15 +4,21 @@ from pathlib import Path
 import pytest
 from flexmock import flexmock
 from jsonschema.exceptions import ValidationError
+from os import chdir
 
+from tests.spellbook import TESTS_DIR
 from ogr.abstract import GitProject, GitService
 from packit.config import (
     JobConfig,
     PackageConfig,
     TriggerType,
+    SyncFilesConfig,
+    SyncFilesItem,
     get_packit_config_from_repo,
     Config,
 )
+
+from packit.sync import get_wildcard_resolved_sync_files
 
 
 def test_job_config_equal():
@@ -106,11 +112,15 @@ def test_job_config_parse(raw, expected_config):
 def test_package_config_equal():
     assert PackageConfig(
         specfile_path="fedora/package.spec",
-        synced_files=["a", "b"],
+        synced_files=SyncFilesConfig(
+            files_to_sync=[SyncFilesItem(src="packit.yaml", dest="packit.yaml")]
+        ),
         jobs=[JobConfig(trigger=TriggerType.release, release_to=["f28"], metadata={})],
     ) == PackageConfig(
         specfile_path="fedora/package.spec",
-        synced_files=["a", "b"],
+        synced_files=SyncFilesConfig(
+            files_to_sync=[SyncFilesItem(src="packit.yaml", dest="packit.yaml")]
+        ),
         jobs=[JobConfig(trigger=TriggerType.release, release_to=["f28"], metadata={})],
     )
 
@@ -120,21 +130,33 @@ def test_package_config_equal():
     [
         PackageConfig(
             specfile_path="fedora/other-package.spec",
-            synced_files=["a", "b"],
+            synced_files=SyncFilesConfig(
+                files_to_sync=[
+                    SyncFilesItem(src="a", dest="a"),
+                    SyncFilesItem(src="b", dest="b"),
+                ]
+            ),
             jobs=[
                 JobConfig(trigger=TriggerType.release, release_to=["f28"], metadata={})
             ],
         ),
         PackageConfig(
             specfile_path="fedora/package.spec",
-            synced_files=["b"],
+            synced_files=SyncFilesConfig(
+                files_to_sync=[SyncFilesItem(src="c", dest="c")]
+            ),
             jobs=[
                 JobConfig(trigger=TriggerType.release, release_to=["f28"], metadata={})
             ],
         ),
         PackageConfig(
             specfile_path="fedora/package.spec",
-            synced_files=["a", "b"],
+            synced_files=SyncFilesConfig(
+                files_to_sync=[
+                    SyncFilesItem(src="a", dest="a"),
+                    SyncFilesItem(src="b", dest="b"),
+                ]
+            ),
             jobs=[
                 JobConfig(
                     trigger=TriggerType.pull_request, release_to=["f28"], metadata={}
@@ -143,14 +165,24 @@ def test_package_config_equal():
         ),
         PackageConfig(
             specfile_path="fedora/package.spec",
-            synced_files=["a", "b"],
+            synced_files=SyncFilesConfig(
+                files_to_sync=[
+                    SyncFilesItem(src="c", dest="c"),
+                    SyncFilesItem(src="d", dest="d"),
+                ]
+            ),
             jobs=[
                 JobConfig(trigger=TriggerType.release, release_to=["f29"], metadata={})
             ],
         ),
         PackageConfig(
             specfile_path="fedora/package.spec",
-            synced_files=["a", "b"],
+            synced_files=SyncFilesConfig(
+                files_to_sync=[
+                    SyncFilesItem(src="c", dest="c"),
+                    SyncFilesItem(src="d", dest="d"),
+                ]
+            ),
             jobs=[
                 JobConfig(
                     trigger=TriggerType.release, release_to=["f28"], metadata={"a": "b"}
@@ -163,7 +195,12 @@ def test_package_config_not_equal(not_equal_package_config):
     assert (
         not PackageConfig(
             specfile_path="fedora/package.spec",
-            synced_files=["a", "b"],
+            synced_files=SyncFilesConfig(
+                files_to_sync=[
+                    SyncFilesItem(src="c", dest="c"),
+                    SyncFilesItem(src="d", dest="d"),
+                ]
+            ),
             jobs=[
                 JobConfig(trigger=TriggerType.release, release_to=["f28"], metadata={})
             ],
@@ -177,12 +214,18 @@ def test_package_config_not_equal(not_equal_package_config):
     [
         ({}, False),
         ({"specfile_path": "fedora/package.spec"}, False),
-        ({"synced_files": ["fedora/package.spec"]}, False),
+        (
+            {
+                "specfile_path": "fedora/package.spec",
+                "synced_files": "fedora/foobar.spec",
+            },
+            False,
+        ),
         ({"jobs": [{"trigger": "release", "release_to": ["f28"]}]}, False),
         (
             {
                 "specfile_path": "fedora/package.spec",
-                "synced_files": ["fedora/package.spec"],
+                "synced_files": ["fedora/foobar.spec"],
                 "jobs": [{"trigger": "release", "release_to": ["f28"]}],
             },
             True,
@@ -190,7 +233,7 @@ def test_package_config_not_equal(not_equal_package_config):
         (
             {
                 "specfile_path": "fedora/package.spec",
-                "synced_files": ["fedora/package.spec", "other", "directory"],
+                "synced_files": ["fedora/foobar.spec", "somefile", "somedirectory"],
                 "jobs": [
                     {"trigger": "release", "release_to": ["f28"]},
                     {"trigger": "pull_request", "release_to": ["f29", "f30", "master"]},
@@ -201,7 +244,7 @@ def test_package_config_not_equal(not_equal_package_config):
         (
             {
                 "specfile_path": "fedora/package.spec",
-                "synced_files": [],
+                "synced_files": [""],
                 "jobs": [
                     {"trigger": "release", "release_to": ["f28"]},
                     {"trigger": "pull_request", "release_to": ["f29", "f30", "master"]},
@@ -254,7 +297,7 @@ def test_package_config_validate(raw, is_valid):
     [
         {},
         {"something": "different"},
-        {"synced_files": ["fedora/package.spec"]},
+        {"synced_files": ["fedora/package.spec", "somefile"]},
         {"jobs": [{"trigger": "release", "release_to": ["f28"]}]},
     ],
 )
@@ -274,7 +317,13 @@ def test_package_config_parse_error(raw):
             },
             PackageConfig(
                 specfile_path="fedora/package.spec",
-                synced_files=["fedora/package.spec"],
+                synced_files=SyncFilesConfig(
+                    files_to_sync=[
+                        SyncFilesItem(
+                            src="fedora/package.spec", dest="fedora/package.spec"
+                        )
+                    ]
+                ),
                 jobs=[
                     JobConfig(
                         trigger=TriggerType.release, release_to=["f28"], metadata={}
@@ -287,7 +336,7 @@ def test_package_config_parse_error(raw):
                 "specfile_path": "fedora/package.spec",
                 "synced_files": [
                     "fedora/package.spec",
-                    "some",
+                    "somefile",
                     "other",
                     "directory/files",
                 ],
@@ -295,12 +344,16 @@ def test_package_config_parse_error(raw):
             },
             PackageConfig(
                 specfile_path="fedora/package.spec",
-                synced_files=[
-                    "fedora/package.spec",
-                    "some",
-                    "other",
-                    "directory/files",
-                ],
+                synced_files=SyncFilesConfig(
+                    files_to_sync=[
+                        SyncFilesItem(
+                            src="fedora/package.spec", dest="fedora/package.spec"
+                        ),
+                        SyncFilesItem(src="somefile", dest="somefile"),
+                        SyncFilesItem(src="other", dest="other"),
+                        SyncFilesItem(src="directory/files", dest="directory/files"),
+                    ]
+                ),
                 jobs=[
                     JobConfig(
                         trigger=TriggerType.release, release_to=["f28"], metadata={}
@@ -311,22 +364,18 @@ def test_package_config_parse_error(raw):
         (
             {
                 "specfile_path": "fedora/package.spec",
-                "synced_files": [
-                    "fedora/package.spec",
-                    "some",
-                    "other",
-                    "directory/files",
-                ],
+                "synced_files": ["fedora/package.spec"],
                 "jobs": [{"trigger": "release", "release_to": ["f28"]}],
             },
             PackageConfig(
                 specfile_path="fedora/package.spec",
-                synced_files=[
-                    "fedora/package.spec",
-                    "some",
-                    "other",
-                    "directory/files",
-                ],
+                synced_files=SyncFilesConfig(
+                    files_to_sync=[
+                        SyncFilesItem(
+                            src="fedora/package.spec", dest="fedora/package.spec"
+                        )
+                    ]
+                ),
                 jobs=[
                     JobConfig(
                         trigger=TriggerType.release, release_to=["f28"], metadata={}
@@ -337,23 +386,20 @@ def test_package_config_parse_error(raw):
         (
             {
                 "specfile_path": "fedora/package.spec",
-                "synced_files": [
-                    "fedora/package.spec",
-                    "some",
-                    "other",
-                    "directory/files",
-                ],
+                "synced_files": ["fedora/package.spec", "somefile"],
                 "jobs": [{"trigger": "release", "release_to": ["f28"]}],
                 "something": "stupid",
             },
             PackageConfig(
                 specfile_path="fedora/package.spec",
-                synced_files=[
-                    "fedora/package.spec",
-                    "some",
-                    "other",
-                    "directory/files",
-                ],
+                synced_files=SyncFilesConfig(
+                    files_to_sync=[
+                        SyncFilesItem(
+                            src="fedora/package.spec", dest="fedora/package.spec"
+                        ),
+                        SyncFilesItem(src="somefile", dest="somefile"),
+                    ]
+                ),
                 jobs=[
                     JobConfig(
                         trigger=TriggerType.release, release_to=["f28"], metadata={}
@@ -364,12 +410,7 @@ def test_package_config_parse_error(raw):
         (
             {
                 "specfile_path": "fedora/package.spec",
-                "synced_files": [
-                    "fedora/package.spec",
-                    "some",
-                    "other",
-                    "directory/files",
-                ],
+                "synced_files": ["fedora/package.spec"],
                 "jobs": [{"trigger": "release", "release_to": ["f28"]}],
                 "something": "stupid",
                 "upstream_project_url": "https://github.com/asd/qwe",
@@ -378,12 +419,13 @@ def test_package_config_parse_error(raw):
             },
             PackageConfig(
                 specfile_path="fedora/package.spec",
-                synced_files=[
-                    "fedora/package.spec",
-                    "some",
-                    "other",
-                    "directory/files",
-                ],
+                synced_files=SyncFilesConfig(
+                    files_to_sync=[
+                        SyncFilesItem(
+                            src="fedora/package.spec", dest="fedora/package.spec"
+                        )
+                    ]
+                ),
                 jobs=[
                     JobConfig(
                         trigger=TriggerType.release, release_to=["f28"], metadata={}
@@ -435,7 +477,6 @@ def test_dist_git_package_url():
         "downstream_package_name": "packit",
         "dist_git_namespace": "awesome",
         "specfile_path": "fedora/package.spec",
-        "synced_files": [],
     }
     new_pc = PackageConfig.get_from_dict(di)
     pc = PackageConfig(
@@ -443,7 +484,6 @@ def test_dist_git_package_url():
         downstream_package_name="packit",
         dist_git_namespace="awesome",
         specfile_path="fedora/package.spec",
-        synced_files=[],
     )
     assert pc == new_pc
     assert pc.dist_git_package_url == "https://packit.dev/awesome/packit.git"
@@ -453,8 +493,13 @@ def test_dist_git_package_url():
 @pytest.mark.parametrize(
     "content",
     [
-        "---\nspecfile_path: packit.spec\nsynced_files:\n  - packit.spec\n  - .packit.yaml\n",
-        '{"specfile_path": "packit.spec", "synced_files": ["packit.spec", ".packit.yaml"]}',
+        "---\nspecfile_path: packit.spec\n"
+        "synced_files:\n"
+        "  - packit.spec\n"
+        "  - src: .packit.yaml\n"
+        "    dest: .packit2.yaml",
+        '{"specfile_path": "packit.spec", "synced_files": ["packit.spec", '
+        '{"src": ".packit.yaml", "dest": ".packit2.yaml"}]}',
     ],
 )
 def test_get_packit_config_from_repo(content):
@@ -463,7 +508,12 @@ def test_get_packit_config_from_repo(content):
     config = get_packit_config_from_repo(sourcegit_project=git_project, ref="")
     assert isinstance(config, PackageConfig)
     assert config.specfile_path == "packit.spec"
-    assert set(config.synced_files) == {"packit.spec", ".packit.yaml"}
+    assert config.synced_files == SyncFilesConfig(
+        files_to_sync=[
+            SyncFilesItem(src="packit.spec", dest="packit.spec"),
+            SyncFilesItem(src=".packit.yaml", dest=".packit2.yaml"),
+        ]
+    )
 
 
 def test_get_user_config(tmpdir):
@@ -494,3 +544,69 @@ def test_get_user_config(tmpdir):
         None
     )
     assert config.pagure_fork_token == "o"
+
+
+@pytest.mark.parametrize(
+    "packit_files,real_files",
+    [
+        (
+            SyncFilesConfig(
+                files_to_sync=[SyncFilesItem(src="conftest.py", dest="conftest.py")]
+            ),
+            [{"src": "conftest.py", "dest": "conftest.py"}],
+        ),
+        (
+            SyncFilesConfig(
+                files_to_sync=[
+                    SyncFilesItem(src="__init__.py", dest="__init__.py"),
+                    SyncFilesItem(src="conftest.py", dest="conftest.py"),
+                    SyncFilesItem(src="spellbook.py", dest="spellbook.py"),
+                ]
+            ),
+            [
+                {"src": "__init__.py", "dest": "__init__.py"},
+                {"src": "conftest.py", "dest": "conftest.py"},
+                {"src": "spellbook.py", "dest": "spellbook.py"},
+            ],
+        ),
+        (
+            SyncFilesConfig(files_to_sync=[SyncFilesItem(src="*.py", dest="tests")]),
+            [
+                {"src": "__init__.py", "dest": "tests"},
+                {"src": "conftest.py", "dest": "tests"},
+                {"src": "spellbook.py", "dest": "tests"},
+            ],
+        ),
+        (
+            SyncFilesConfig(
+                files_to_sync=[SyncFilesItem(src="unit/test_u*.py", dest="units")]
+            ),
+            [{"src": "unit/test_utils.py", "dest": "units"}],
+        ),
+        (
+            SyncFilesConfig(
+                files_to_sync=[
+                    SyncFilesItem(src="integration/test_u*.py", dest="units")
+                ]
+            ),
+            [
+                {"src": "integration/test_upstream.py", "dest": "units"},
+                {"src": "integration/test_update.py", "dest": "units"},
+            ],
+        ),
+    ],
+)
+def test_sync_files(packit_files, real_files):
+    chdir(TESTS_DIR)
+    pc = PackageConfig(
+        dist_git_base_url="https://packit.dev/",
+        downstream_package_name="packit",
+        dist_git_namespace="awesome",
+        specfile_path="fedora/package.spec",
+        synced_files=packit_files,
+    )
+    get_wildcard_resolved_sync_files(pc)
+    assert pc.synced_files
+    for files in pc.synced_files.files_to_sync:
+        assert [real for real in real_files if files.src == real.get("src")]
+        assert [real for real in real_files if files.dest == real["dest"]]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -213,7 +213,6 @@ def test_package_config_not_equal(not_equal_package_config):
     "raw,is_valid",
     [
         ({}, False),
-        ({"specfile_path": "fedora/package.spec"}, False),
         (
             {
                 "specfile_path": "fedora/package.spec",
@@ -244,7 +243,7 @@ def test_package_config_not_equal(not_equal_package_config):
         (
             {
                 "specfile_path": "fedora/package.spec",
-                "synced_files": [""],
+                "synced_files": ["fedora/foobar.spec"],
                 "jobs": [
                     {"trigger": "release", "release_to": ["f28"]},
                     {"trigger": "pull_request", "release_to": ["f29", "f30", "master"]},
@@ -256,11 +255,11 @@ def test_package_config_not_equal(not_equal_package_config):
         (
             {
                 "specfile_path": "fedora/package.spec",
+                "synced_files": ["fedora/foobar.spec"],
                 "actions": {
                     "pre-sync": "some/pre-sync/command --option",
                     "upstream-version": "get-me-upstream-version",
                 },
-                "synced_files": [],
                 "jobs": [
                     {"trigger": "release", "release_to": ["f28"]},
                     {"trigger": "pull_request", "release_to": ["f29", "f30", "master"]},
@@ -273,7 +272,6 @@ def test_package_config_not_equal(not_equal_package_config):
             {
                 "specfile_path": "fedora/package.spec",
                 "actions": ["actions" "has", "to", "be", "key", "value"],
-                "synced_files": [],
                 "jobs": [
                     {"trigger": "release", "release_to": ["f28"]},
                     {"trigger": "pull_request", "release_to": ["f29", "f30", "master"]},
@@ -452,11 +450,11 @@ def test_package_config_parse_error(raw):
             },
             PackageConfig(
                 specfile_path="fedora/package.spec",
-                synced_files=[],
                 actions={
                     "pre-sync": "some/pre-sync/command --option",
                     "upstream-version": "get-me-upstream-version",
                 },
+                synced_files=SyncFilesConfig(files_to_sync=None),
                 jobs=[],
                 upstream_project_url="https://github.com/asd/qwe",
                 upstream_project_name="qwe",
@@ -476,6 +474,7 @@ def test_dist_git_package_url():
         "dist_git_base_url": "https://packit.dev/",
         "downstream_package_name": "packit",
         "dist_git_namespace": "awesome",
+        "synced_files": ["fedora/foobar.spec"],
         "specfile_path": "fedora/package.spec",
     }
     new_pc = PackageConfig.get_from_dict(di)
@@ -483,6 +482,11 @@ def test_dist_git_package_url():
         dist_git_base_url="https://packit.dev/",
         downstream_package_name="packit",
         dist_git_namespace="awesome",
+        synced_files=SyncFilesConfig(
+            files_to_sync=[
+                SyncFilesItem(src="fedora/foobar.spec", dest="fedora/foobar.spec")
+            ]
+        ),
         specfile_path="fedora/package.spec",
     )
     assert pc == new_pc

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist =
     py37
 
 [testenv]
+setenv =
+    PYTHONDONTWRITEBYTECODE = 1
 deps =
     flexmock
     pytest


### PR DESCRIPTION
Fixes #171 

PR adds support for copying directories by packit.
Functions `propose-update` and `sync-from-downstream` are affected for now.

What is covered:
- [x] `propose-update` is able to copy directories
- [x] `sync-from-downstream` is able to copy directories
- [x] tests for copying directories are covered.
- [x] configuration document with the new .packit.yaml format is updated