### PR TITLE
Fixes #157 Create common ancestor for Gits

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -47,6 +47,7 @@ class PackitAPI:
             base=f"remotes/origin/{dist_git_branch}",
             setup_tracking=True,
         )
+
         self.dg.update_branch(dist_git_branch)
         self.dg.checkout_branch(dist_git_branch)
 
@@ -115,6 +116,7 @@ class PackitAPI:
                 base=f"remotes/origin/{dist_git_branch}",
                 setup_tracking=True,
             )
+
             self.dg.update_branch(dist_git_branch)
             self.dg.checkout_branch(dist_git_branch)
 
@@ -247,11 +249,13 @@ class PackitAPI:
         :param scratch: should the build be a scratch build?
         """
         logger.info(f"Using {dist_git_branch!r} dist-git branch")
+
         self.dg.create_branch(
             dist_git_branch,
             base=f"remotes/origin/{dist_git_branch}",
             setup_tracking=True,
         )
+
         self.dg.update_branch(dist_git_branch)
         self.dg.checkout_branch(dist_git_branch)
 

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -1,0 +1,100 @@
+import git
+import logging
+from typing import Optional
+
+from rebasehelper.specfile import SpecFile
+from packit.config import Config, PackageConfig
+from packit.exceptions import PackitException
+from packit.local_project import LocalProject
+
+logger = logging.getLogger(__name__)
+
+
+class PackitRepositoryBase:
+    def __init__(self, config: Config, package_config: PackageConfig) -> None:
+        self.config = config
+        self.package_config = package_config
+        self._specfile = None
+
+    @property
+    def local_project(self) -> LocalProject:
+        """
+        :return: an instance of LocalProject
+        """
+        raise NotImplementedError
+
+    @property
+    def specfile(self) -> SpecFile:
+        """
+        :return: an instance of SpecFile
+        """
+        raise NotImplementedError
+
+    @property
+    def specfile_path(self) -> Optional[str]:
+        """
+        :return: a path to a Spec file
+        """
+        raise NotImplementedError
+
+    def create_branch(
+        self, branch_name: str, base: str = "HEAD", setup_tracking: bool = False
+    ) -> git.Head:
+        """
+        Create a new git branch in dist-git
+
+        :param branch_name: name of the branch to check out and fetch
+        :param base: we base our new branch on this one
+        :param setup_tracking: set up remote tracking
+               (exc will be raised if the branch is not in the remote)
+        :return the branch which was just created
+        """
+        # it's not an error if the branch already exists
+        origin = self.local_project.git_repo.remote("origin")
+        head = self.local_project.git_repo.create_head(branch_name, commit=base)
+
+        if setup_tracking:
+            if branch_name in origin.refs:
+                remote_ref = origin.refs[branch_name]
+            else:
+                raise PackitException("Remote origin doesn't have ref %s" % branch_name)
+            # this is important to fedpkg: build can't find the tracking branch otherwise
+            head.set_tracking_branch(remote_ref)
+
+        return head
+
+    def checkout_branch(self, git_ref: str):
+        """
+        Perform a `git checkout`
+
+        :param git_ref: ref to check out
+        """
+        if git_ref in self.local_project.git_repo.heads:
+            head = self.local_project.git_repo.heads[git_ref]
+        else:
+            raise PackitException(f"Branch {git_ref} does not exist")
+        head.checkout()
+
+    def commit(self, title: str, msg: str, prefix: str = "[packit] ") -> None:
+        """
+        Perform `git add -A` and `git commit`
+        """
+        logger.debug("About to add all & commit")
+        main_msg = f"{prefix}{title}"
+        if not self.local_project.git_repo.is_dirty():
+            raise PackitException(
+                "No changes are present in the dist-git repo: nothing to commit."
+            )
+        self.local_project.git_repo.git.add("-A")
+        self.local_project.git_repo.index.write()
+        commit_args = ["-s", "-m", main_msg]
+        if msg:
+            commit_args += ["-m", msg]
+        # TODO: attach git note to every commit created
+        # TODO: implement cleaning policy: once the PR is closed (merged/refused), remove the branch
+        #       make this configurable so that people know this would happen, don't clean by default
+        #       we should likely clean only merged PRs by default
+        # TODO: implement signing properly: we need to create a cert for the bot,
+        #       distribute it to the container, prepare git config and then we can start signing
+        # TODO: make -s configurable
+        self.local_project.git_repo.git.commit(*commit_args)

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -11,12 +11,14 @@ from ogr.services.pagure import PagureService
 from packit.config import Config, PackageConfig
 from packit.exceptions import PackitException
 from packit.local_project import LocalProject
+
 from packit.fedpkg import FedPKG
+from packit.base_git import PackitRepositoryBase
 
 logger = logging.getLogger(__name__)
 
 
-class DistGit:
+class DistGit(PackitRepositoryBase):
     """
     A class which interacts with dist-git and pagure-over-dist-git API.
 
@@ -31,8 +33,7 @@ class DistGit:
     """
 
     def __init__(self, config: Config, package_config: PackageConfig):
-        self.config = config
-        self.package_config = package_config
+        super().__init__(config=config, package_config=package_config)
 
         self._local_project = None
 
@@ -72,7 +73,7 @@ class DistGit:
         return None
 
     @property
-    def specfile(self):
+    def specfile(self) -> SpecFile:
         if self._specfile is None:
             self._specfile = SpecFile(
                 path=self.specfile_path,
@@ -80,32 +81,6 @@ class DistGit:
                 changelog_entry=None,
             )
         return self._specfile
-
-    def create_branch(
-        self, branch_name: str, base: str = "HEAD", setup_tracking: bool = False
-    ) -> git.Head:
-        """
-        Create a new git branch in dist-git
-
-        :param branch_name: name of the branch to check out and fetch
-        :param base: we base our new branch on this one
-        :param setup_tracking: set up remote tracking (exc raised if branch not in remote)
-        :return the branch which was just created
-        """
-        logger.debug(f"About to create a new git branch {branch_name!r} in dist-git")
-        # it's not an error if the branch already exists
-        origin = self.local_project.git_repo.remote("origin")
-        head = self.local_project.git_repo.create_head(branch_name, commit=base)
-
-        if setup_tracking:
-            try:
-                remote_ref = origin.refs[branch_name]
-            except IndexError:
-                raise PackitException("Remote origin doesn't have ref %s" % branch_name)
-            # this is important to fedpkg: build can't find the tracking branch otherwise
-            head.set_tracking_branch(remote_ref)
-
-        return head
 
     def update_branch(self, branch_name: str):
         """
@@ -127,43 +102,6 @@ class DistGit:
                 f"Branch {branch_name} does not exist in the origin remote."
             )
         head.set_commit(remote_ref)
-
-    def checkout_branch(self, git_ref: str):
-        """
-        Perform a `git checkout`
-
-        :param git_ref: ref to check out
-        """
-        logger.debug(f"About to checkout {git_ref!r}")
-        try:
-            head = self.local_project.git_repo.heads[git_ref]
-        except IndexError:
-            raise PackitException(f"Branch {git_ref} does not exist")
-        head.checkout()
-
-    def commit(self, title: str, msg: str, prefix: str = "[packit] ") -> None:
-        """
-        Perform `git add -A` and `git commit`
-        """
-        logger.debug("About to add all & commit")
-        main_msg = f"{prefix}{title}"
-        if not self.local_project.git_repo.is_dirty():
-            raise PackitException(
-                "No changes are present in the dist-git repo: nothing to commit."
-            )
-        self.local_project.git_repo.git.add("-A")
-        self.local_project.git_repo.index.write()
-        commit_args = ["-s", "-m", main_msg]
-        if msg:
-            commit_args += ["-m", msg]
-        # TODO: attach git note to every commit created
-        # TODO: implement cleaning policy: once the PR is closed (merged/refused), remove the branch
-        #       make this configurable so that people know this would happen, don't clean by default
-        #       we should likely clean only merged PRs by default
-        # TODO: implement signing properly: we need to create a cert for the bot,
-        #       distribute it to the container, prepare git config and then we can start signing
-        # TODO: make -s configurable
-        self.local_project.git_repo.git.commit(*commit_args)
 
     def push_to_fork(
         self, branch_name: str, fork_remote_name: str = "fork", force: bool = False

--- a/tests/integration/test_distgit.py
+++ b/tests/integration/test_distgit.py
@@ -10,7 +10,7 @@ from packit.exceptions import PackitException
 def test_distgit_commit_empty(distgit_instance):
     d, dg = distgit_instance
     with pytest.raises(PackitException) as ex:
-        dg.commit(dg.local_project, "", "")
+        dg.commit("", "")
     assert (
         str(ex.value)
         == "No changes are present in the dist-git repo: nothing to commit."

--- a/tests/integration/test_distgit.py
+++ b/tests/integration/test_distgit.py
@@ -10,7 +10,7 @@ from packit.exceptions import PackitException
 def test_distgit_commit_empty(distgit_instance):
     d, dg = distgit_instance
     with pytest.raises(PackitException) as ex:
-        dg.commit("", "")
+        dg.commit(dg.local_project, "", "")
     assert (
         str(ex.value)
         == "No changes are present in the dist-git repo: nothing to commit."


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

The pull request adds a common ancestor for Git (upstream/downstream) repo. Do not use the same functions twice.

- [x] Common class for Gits is created
- [x] Move functions into common class is done
- [x] tests passed
