### PR TITLE
onboard pagure.io-based projects

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -28,6 +28,8 @@ import logging
 from pathlib import Path
 from typing import Sequence
 
+from packit.local_project import LocalProject
+
 from packit.config import Config, PackageConfig
 from packit.distgit import DistGit
 from packit.exceptions import PackitException
@@ -40,9 +42,15 @@ logger = logging.getLogger(__name__)
 
 
 class PackitAPI:
-    def __init__(self, config: Config, package_config: PackageConfig) -> None:
+    def __init__(
+        self,
+        config: Config,
+        package_config: PackageConfig,
+        upstream_local_project: LocalProject,
+    ) -> None:
         self.config = config
         self.package_config = package_config
+        self.upstream_local_project = upstream_local_project
 
         self._up = None
         self._dg = None
@@ -50,7 +58,11 @@ class PackitAPI:
     @property
     def up(self):
         if self._up is None:
-            self._up = Upstream(config=self.config, package_config=self.package_config)
+            self._up = Upstream(
+                config=self.config,
+                package_config=self.package_config,
+                local_project=self.upstream_local_project,
+            )
         return self._up
 
     @property
@@ -352,7 +364,7 @@ class PackitAPI:
 
     def status(self):
 
-        status = Status(self.config, self.package_config)
+        status = Status(self.config, self.package_config, self.up, self.dg)
 
         status.get_downstream_prs()
         status.get_dg_versions()

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -99,11 +99,13 @@ class PackitRepositoryBase:
         """
         logger.debug("About to add all & commit")
         main_msg = f"{prefix}{title}"
+        # add files to index in case some are untracked
+        # untracked files don't make a git repo dirty, unless they are staged
+        self.local_project.git_repo.git.add("-A")
         if not self.local_project.git_repo.is_dirty():
             raise PackitException(
                 "No changes are present in the dist-git repo: nothing to commit."
             )
-        self.local_project.git_repo.git.add("-A")
         self.local_project.git_repo.index.write()
         commit_args = ["-s", "-m", main_msg]
         if msg:

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -33,17 +33,13 @@ logger = logging.getLogger(__name__)
 
 
 class PackitRepositoryBase:
+    # mypy complains when this is a property
+    local_project: LocalProject
+
     def __init__(self, config: Config, package_config: PackageConfig) -> None:
         self.config = config
         self.package_config = package_config
         self._specfile = None
-
-    @property
-    def local_project(self) -> LocalProject:
-        """
-        :return: an instance of LocalProject
-        """
-        raise NotImplementedError
 
     @property
     def specfile(self) -> SpecFile:

--- a/packit/cli/srpm.py
+++ b/packit/cli/srpm.py
@@ -36,12 +36,22 @@ logger = logging.getLogger("packit")
 @click.option(
     "--output", metavar="FILE", help="Write the SRPM to FILE instead of current dir."
 )
+@click.option(
+    "--remote",
+    default=None,
+    help=(
+        "Name of the remote where packit should push. "
+        "if this is not specified, it pushes to a fork if the repo can be forked."
+    ),
+)
 @click.argument(
-    "path_or_url", type=LocalProjectParameter(), default=os.path.abspath(os.path.curdir)
+    "path_or_url",
+    type=LocalProjectParameter(remote_param_name="remote"),
+    default=os.path.abspath(os.path.curdir),
 )
 @pass_config
 @cover_packit_exception
-def srpm(config, output, path_or_url):
+def srpm(config, output, path_or_url, remote):
     """
     Create new SRPM (.src.rpm file) using content of the upstream repository.
 

--- a/packit/cli/srpm.py
+++ b/packit/cli/srpm.py
@@ -40,8 +40,8 @@ logger = logging.getLogger("packit")
     "--remote",
     default=None,
     help=(
-        "Name of the remote where packit should push. "
-        "if this is not specified, it pushes to a fork if the repo can be forked."
+        "Name of the remote to discover upstream project URL, "
+        "If this is not specified, default to origin."
     ),
 )
 @click.argument(

--- a/packit/cli/sync_from_downstream.py
+++ b/packit/cli/sync_from_downstream.py
@@ -38,13 +38,22 @@ logger = logging.getLogger(__file__)
 
 @click.command("sync-from-downstream", context_settings=get_context_settings())
 @click.option(
-    "--dist-git-branch", help="Source branch in dist-git for sync.", default="master"
+    "--dist-git-branch",
+    help="Source branch in dist-git to sync from.",
+    default="master",
 )
 @click.option(
     "--upstream-branch", help="Target branch in upstream to sync to.", default="master"
 )
-@click.option("--no-pr", is_flag=True, help="Pull request is not create.")
-@click.option("--fork/--no-fork", is_flag=True, default=True, help="Push to a fork.")
+@click.option(
+    "--no-pr", is_flag=True, help="Do not create a pull request to upstream repository."
+)
+@click.option(
+    "--fork/--no-fork",
+    is_flag=True,
+    default=True,
+    help="Push to a fork before creating a pull request.",
+)
 @click.option(
     "--remote",
     default=None,

--- a/packit/cli/sync_from_downstream.py
+++ b/packit/cli/sync_from_downstream.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__file__)
 @click.option("--no-pr", is_flag=True, help="Pull request is not create.")
 @click.option("--fork/--no-fork", is_flag=True, default=True, help="Push to a fork.")
 @click.option(
-    "--remote-name",
+    "--remote",
     default=None,
     help=(
         "Name of the remote where packit should push. "
@@ -54,12 +54,14 @@ logger = logging.getLogger(__file__)
     ),
 )
 @click.argument(
-    "path_or_url", type=LocalProjectParameter(), default=os.path.abspath(os.path.curdir)
+    "path_or_url",
+    type=LocalProjectParameter(remote_param_name="remote"),
+    default=os.path.abspath(os.path.curdir),
 )
-@pass_config
 @cover_packit_exception
+@pass_config
 def sync_from_downstream(
-    config, dist_git_branch, upstream_branch, no_pr, path_or_url, fork, remote_name
+    config, dist_git_branch, upstream_branch, no_pr, path_or_url, fork, remote
 ):
     """
     Copy synced files from Fedora dist-git into upstream by opening a pull request.
@@ -69,9 +71,5 @@ def sync_from_downstream(
     """
     api = get_packit_api(config=config, local_project=path_or_url)
     api.sync_from_downstream(
-        dist_git_branch,
-        upstream_branch,
-        no_pr=no_pr,
-        fork=fork,
-        remote_name=remote_name,
+        dist_git_branch, upstream_branch, no_pr=no_pr, fork=fork, remote_name=remote
     )

--- a/packit/cli/sync_from_downstream.py
+++ b/packit/cli/sync_from_downstream.py
@@ -59,7 +59,7 @@ logger = logging.getLogger(__file__)
     default=None,
     help=(
         "Name of the remote where packit should push. "
-        "if this is not specified, it pushes to a fork if the repo can be forked."
+        "If this is not specified, push to a fork if the repo can be forked."
     ),
 )
 @click.argument(

--- a/packit/cli/types.py
+++ b/packit/cli/types.py
@@ -32,12 +32,16 @@ class LocalProjectParameter(click.ParamType):
 
     name = "path_or_url"
 
-    def __init__(self, branch_param_name: str = None) -> None:
+    def __init__(
+        self, branch_param_name: str = None, remote_param_name: str = None
+    ) -> None:
         """
         :param branch_param_name: name of the cli function parameter (not the option name)
+        :param remote_param_name: name of the remote cli function parameter (not the option name)
         """
         super().__init__()
         self.branch_param_name = branch_param_name
+        self.remote_param_name = remote_param_name
 
     def convert(self, value, param, ctx):
         try:
@@ -49,8 +53,11 @@ class LocalProjectParameter(click.ParamType):
                     for param in ctx.command.params:
                         if param.name == self.branch_param_name:
                             branch_name = param.default
+            remote_name = ctx.params.get(self.remote_param_name, None)
 
-            local_project = LocalProject(path_or_url=value, ref=branch_name)
+            local_project = LocalProject(
+                path_or_url=value, ref=branch_name, remote=remote_name
+            )
             if not local_project.working_dir and not local_project.git_url:
                 self.fail(
                     "Parameter is not an existing directory nor correct git url.",

--- a/packit/cli/update.py
+++ b/packit/cli/update.py
@@ -59,8 +59,18 @@ logger = logging.getLogger(__file__)
     default=False,
     help="Upload the new sources also when the archive is already in the lookaside cache.",
 )
+@click.option(
+    "--remote",
+    default=None,
+    help=(
+        "Name of the remote to discover upstream project URL, "
+        "if this is not specified, origin is assumed."
+    ),
+)
 @click.argument(
-    "path_or_url", type=LocalProjectParameter(), default=os.path.abspath(os.path.curdir)
+    "path_or_url",
+    type=LocalProjectParameter(remote_param_name="remote"),
+    default=os.path.abspath(os.path.curdir),
 )
 @click.argument("version", required=False)
 @pass_config
@@ -73,6 +83,7 @@ def update(
     local_content,
     path_or_url,
     version,
+    remote,  # click introspects this in LocalProjectParameter
 ):
     """
     Release current upstream release into Fedora

--- a/packit/cli/update.py
+++ b/packit/cli/update.py
@@ -64,7 +64,7 @@ logger = logging.getLogger(__file__)
     default=None,
     help=(
         "Name of the remote to discover upstream project URL, "
-        "if this is not specified, origin is assumed."
+        "If this is not specified, default to origin."
     ),
 )
 @click.argument(

--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -101,5 +101,9 @@ def get_packit_api(
         package_config.downstream_project_url = dist_git_path
     package_config.upstream_project_url = local_project.working_dir
 
-    api = PackitAPI(config=config, package_config=package_config)
+    api = PackitAPI(
+        config=config,
+        package_config=package_config,
+        upstream_local_project=local_project,
+    )
     return api

--- a/packit/config.py
+++ b/packit/config.py
@@ -178,18 +178,22 @@ class SyncFilesItem(NamedTuple):
     src: str
     dest: str
 
-    def __eq__(self, other: object):
-        if not isinstance(other, SyncFilesItem):
-            return NotImplemented
+    def __repr__(self):
+        return f"[src={self.src}, dest={self.dest}]"
 
-        if self.src == other.src and self.dest == other.dest:
-            return True
-        return False
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SyncFilesItem):
+            raise NotImplementedError()
+
+        return self.src == other.src and self.dest == other.dest
 
 
 class SyncFilesConfig:
     def __init__(self, files_to_sync: List[SyncFilesItem]):
         self.files_to_sync = files_to_sync
+
+    def __repr__(self):
+        return f"{self.files_to_sync!r}"
 
     @classmethod
     def get_from_dict(cls, raw_dict: dict, validate=True) -> "SyncFilesConfig":

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -271,11 +271,11 @@ class LocalProject:
         if self.git_repo and not self.git_url:
             old_git_url = self.git_url
             if self.remote:
-                self.git_url = list(self.git_repo.remote(self.remote).urls)[0]
+                self.git_url = next(self.git_repo.remote(self.remote).urls)
             else:
                 # TODO: let's just default to origin
                 # .urls returns generator
-                self.git_url = list(self.git_repo.remote().urls)[0]
+                self.git_url = next(self.git_repo.remote().urls)
             logger.debug(f"remote url of the repo is {self.git_url}")
             # trigger refresh if they are different
             return not (bool(old_git_url) == bool(self.git_url))

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -274,7 +274,6 @@ class LocalProject:
                 self.git_url = next(self.git_repo.remote(self.remote).urls)
             else:
                 # TODO: let's just default to origin
-                # .urls returns generator
                 self.git_url = next(self.git_repo.remote().urls)
             logger.debug(f"remote url of the repo is {self.git_url}")
             # trigger refresh if they are different

--- a/packit/status.py
+++ b/packit/status.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 import logging
+
 from tabulate import tabulate
 
 from packit.config import Config, PackageConfig
@@ -36,12 +37,18 @@ class Status:
     This class provides methods to obtain status of the package
     """
 
-    def __init__(self, config: Config, package_config: PackageConfig):
+    def __init__(
+        self,
+        config: Config,
+        package_config: PackageConfig,
+        upstream: Upstream,
+        distgit: DistGit,
+    ):
         self.config = config
         self.package_config = package_config
 
-        self.up = Upstream(config=self.config, package_config=self.package_config)
-        self.dg = DistGit(config=self.config, package_config=self.package_config)
+        self.up = upstream
+        self.dg = distgit
 
     def get_downstream_prs(self, number_of_prs: int = 5) -> None:
         """

--- a/tests/integration/test_build.py
+++ b/tests/integration/test_build.py
@@ -24,6 +24,7 @@ from os import chdir
 
 from packit.api import PackitAPI
 from packit.config import get_local_package_config
+from packit.local_project import LocalProject
 from tests.spellbook import get_test_config
 
 
@@ -35,6 +36,7 @@ def test_basic_build(upstream_n_distgit, mock_upstream_remote_functionality):
     pc = get_local_package_config(str(u))
     pc.upstream_project_url = str(u)
     pc.downstream_project_url = str(d)
+    up_lp = LocalProject(path_or_url=u)
 
-    api = PackitAPI(c, pc)
+    api = PackitAPI(c, pc, up_lp)
     api.build("master")

--- a/tests/integration/test_create_update.py
+++ b/tests/integration/test_create_update.py
@@ -28,6 +28,7 @@ from munch import Munch
 
 from packit.api import PackitAPI
 from packit.config import get_local_package_config
+from packit.local_project import LocalProject
 from tests.spellbook import get_test_config, can_a_module_be_imported
 
 
@@ -299,8 +300,9 @@ def test_basic_bodhi_update(
     pc = get_local_package_config(str(u))
     pc.upstream_project_url = str(u)
     pc.downstream_project_url = str(d)
+    up_lp = LocalProject(path_or_url=u)
 
-    api = PackitAPI(c, pc)
+    api = PackitAPI(c, pc, up_lp)
 
     flexmock(
         BodhiClient,

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -28,12 +28,11 @@ import re
 import subprocess
 from pathlib import Path
 
-import github
 import pytest
 from flexmock import flexmock
-from packit.config import Config
 from rebasehelper.versioneer import versioneers_runner
 
+from packit.config import Config
 from packit.exceptions import PackitException
 from tests.spellbook import does_bumpspec_know_new
 
@@ -147,18 +146,4 @@ def test_github_app(upstream_instance, tmpdir):
     )
     ups.config = Config.get_user_config()
 
-    def fake_init(github_app_id, private_key):
-        assert github_app_id == "qwe"
-        assert private_key == "hello!"
-
-    def fake_get_access_token(inst_id):
-        assert inst_id == "asd"
-        return "good"
-
-    flexmock(
-        github.GithubIntegration,
-        __init__=fake_init,
-        get_access_token=fake_get_access_token,
-    )
-
-    assert ups.local_project.git_service._token == "good"
+    assert ups.local_project.git_service._token == "test"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -573,13 +573,13 @@ def test_get_user_config(tmpdir):
 
 
 @pytest.mark.parametrize(
-    "packit_files,real_files",
+    "packit_files,expected",
     [
         (
             SyncFilesConfig(
                 files_to_sync=[SyncFilesItem(src="conftest.py", dest="conftest.py")]
             ),
-            [{"src": "conftest.py", "dest": "conftest.py"}],
+            [SyncFilesItem(src="conftest.py", dest="conftest.py")],
         ),
         (
             SyncFilesConfig(
@@ -590,9 +590,9 @@ def test_get_user_config(tmpdir):
                 ]
             ),
             [
-                {"src": "__init__.py", "dest": "__init__.py"},
-                {"src": "conftest.py", "dest": "conftest.py"},
-                {"src": "spellbook.py", "dest": "spellbook.py"},
+                SyncFilesItem(src="__init__.py", dest="__init__.py"),
+                SyncFilesItem(src="conftest.py", dest="conftest.py"),
+                SyncFilesItem(src="spellbook.py", dest="spellbook.py"),
             ],
         ),
         (
@@ -600,23 +600,23 @@ def test_get_user_config(tmpdir):
                 files_to_sync=[SyncFilesItem(src="functional/", dest="tests")]
             ),
             [
-                {"src": "functional/__init__.py", "dest": "tests"},
-                {"src": "functional/test_srpm.py", "dest": "tests"},
+                SyncFilesItem(src="functional/__init__.py", dest="tests"),
+                SyncFilesItem(src="functional/test_srpm.py", dest="tests"),
             ],
         ),
         (
             SyncFilesConfig(files_to_sync=[SyncFilesItem(src="*.py", dest="tests")]),
             [
-                {"src": "__init__.py", "dest": "tests"},
-                {"src": "conftest.py", "dest": "tests"},
-                {"src": "spellbook.py", "dest": "tests"},
+                SyncFilesItem(src="__init__.py", dest="tests"),
+                SyncFilesItem(src="conftest.py", dest="tests"),
+                SyncFilesItem(src="spellbook.py", dest="tests"),
             ],
         ),
         (
             SyncFilesConfig(
                 files_to_sync=[SyncFilesItem(src="unit/test_u*.py", dest="units")]
             ),
-            [{"src": "unit/test_utils.py", "dest": "units"}],
+            [SyncFilesItem(src="unit/test_utils.py", dest="units")],
         ),
         (
             SyncFilesConfig(
@@ -625,13 +625,13 @@ def test_get_user_config(tmpdir):
                 ]
             ),
             [
-                {"src": "integration/test_upstream.py", "dest": "units"},
-                {"src": "integration/test_update.py", "dest": "units"},
+                SyncFilesItem(src="integration/test_upstream.py", dest="units"),
+                SyncFilesItem(src="integration/test_update.py", dest="units"),
             ],
         ),
     ],
 )
-def test_sync_files(packit_files, real_files):
+def test_sync_files(packit_files, expected):
     chdir(TESTS_DIR)
     pc = PackageConfig(
         dist_git_base_url="https://packit.dev/",
@@ -642,6 +642,4 @@ def test_sync_files(packit_files, real_files):
     )
     get_wildcard_resolved_sync_files(pc)
     assert pc.synced_files
-    for files in pc.synced_files.files_to_sync:
-        assert [real for real in real_files if files.src == real.get("src")]
-        assert [real for real in real_files if files.dest == real["dest"]]
+    assert set(expected).issubset(set(pc.synced_files.files_to_sync))

--- a/tests/unit/test_local_project.py
+++ b/tests/unit/test_local_project.py
@@ -184,9 +184,9 @@ def test_parse_namespace_from_git_project():
 
 def test_parse_git_url_from_git_repo():
     project = LocalProject(
-        git_repo=flexmock()
-        .should_receive("remote")
-        .replace_with(lambda: flexmock(urls=["git@github.com:org/name"]))
+        git_repo=flexmock().should_receive("remote")
+        # must be a generator
+        .replace_with(lambda: flexmock(urls=(x for x in ["git@github.com:org/name"])))
         .once()
         .mock(),
         refresh=False,
@@ -349,8 +349,11 @@ def test_from_path_or_url_ref_path():
     ).and_return(
         flexmock(active_branch="branch", head=flexmock(is_detached=False))
         .should_receive("remote")
+        # must be a generator
         .replace_with(
-            lambda: flexmock(urls=["https://server.git/my_namespace/package_name"])
+            lambda: flexmock(
+                urls=(x for x in ["https://server.git/my_namespace/package_name"])
+            )
         )
         .once()
         .mock()


### PR DESCRIPTION
* sync-from-downstream: improve help descriptions
* propose-update: don't bail if there are only untracked files
* pass upstream_local_project from cli to API
  * this way we don't initialize LocalProject twice; I need this when

just to be clear, the thing which failed with pagure.io based projects was that git_url, namespace and repo_name was computed again and packit picked up default remote which did not work; we need #199 badly to support multiple upstream git forges

TODO:
* [ ] fix tests (I don't think they will pass)
* [ ] update docs

