### PR TITLE
sourcegit support (#213 follow up)

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -1,10 +1,37 @@
-# Actions that can be redefined by the user
+# Actions
+
+You can probably find yourself in a situation where some part of the packit workflow needs to be
+tweaked for your package.
+
+Packit supports some actions, that can be defined in the configuration file.
+The part of the default behaviour is then skipped, and the configured command is called instead.
+
+There are also some hooks presented -- it works as an action without any default behaviour.
+
+Currently, there are the following actions that you can use:
+
 
 |        | name                  | working directory | when run                                                                          | description                               |
 | ------ | --------------------- | ----------------- | --------------------------------------------------------------------------------  | ----------------------------------------- |
-| [hook] | `init`                | upstream git repo | after cloning of the upstream-repo (master) and before other operation            |                                           |
+| [hook] | `post-upstream-clone` | upstream git repo | after cloning of the upstream-repo (master) and before other operation            |                                           |
 | [hook] | `pre-sync`            | upstream git repo | after cloning of the upstream-repo and checkout to the right (release) branch     |                                           |
 |        | `prepare-files`       | upstream git repo | after clone and checkout of upstream and dist-git repo                            | replace patching and archive generation   |
-|        | `patch`               | upstream git repo | after sync of upstream files to the downstream                                    | replace patching                          |
+|        | `create-patches`      | upstream git repo | after sync of upstream files to the downstream                                    | replace patching                          |
 |        | `create-archive`      | upstream git repo | when the archive needs to be created                                              | replace the code for creating an archive  |
 |        | `get-current-version` | upstream git repo | when the current version needs to be found                                        | expect version as a stdout                |
+
+
+In your package config they can be defined like this:
+
+```yaml
+specfile_path: package.spec
+synced_files:
+  - packit.yaml
+  - package.spec
+upstream_project_name: package
+downstream_package_name: package
+dist_git_url: https://src.fedoraproject.org/rpms/package.git
+actions:
+  prepare-files: "make prepare"
+  create-archive: "make archive"
+```

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -1,0 +1,10 @@
+# Actions that can be redefined by the user
+
+|        | name                  | working directory | when run                                                                          | description                               |
+| ------ | --------------------- | ----------------- | --------------------------------------------------------------------------------  | ----------------------------------------- |
+| [hook] | `init`                | upstream git repo | after cloning of the upstream-repo (master) and before other operation            |                                           |
+| [hook] | `pre-sync`            | upstream git repo | after cloning of the upstream-repo and checkout to the right (release) branch     |                                           |
+|        | `prepare-files`       | upstream git repo | after clone and checkout of upstream and dist-git repo                            | replace patching and archive generation   |
+|        | `patch`               | upstream git repo | after sync of upstream files to the downstream                                    | replace patching                          |
+|        | `create-archive`      | upstream git repo | when the archive needs to be created                                              | replace the code for creating an archive  |
+|        | `get-current-version` | upstream git repo | when the current version needs to be found                                        | expect version as a stdout                |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ You should place the file in the root of your upstream repo. Packit accepts thes
  `dist_git_base_url`       | string          | URL of dist-git server, defaults to "https://src.fedoraproject.org/" (has to end with a slash)
  `create_tarball_command`  | list of strings | a command which generates upstream tarball in the root of the upstream directory (defaults to `git archive -o "{package_name}-{version}.tar.gz" --prefix "{package_name}-{version}/" HEAD`)
  `current_version_command` | list of strings | a command which prints current upstream version (hint: `git describe`) (defaults to `git describe --tags --match '*.*'`)
-
+ `actions`                 | string:string   | custom actions/hooks overwriting the default behavior of the workflow (more in [Actions](./actions.md))
 
 ### Minimal sample config
 

--- a/packit/actions.py
+++ b/packit/actions.py
@@ -1,0 +1,60 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from enum import Enum
+from typing import Optional
+
+
+class ActionName(Enum):
+    """
+    Name of the action.
+
+    Can be defined by user in the per-package config file and used to overwrite the default
+    implementation.
+
+    New action needs to be added here and to the table in the `./docs/actions.md`.
+    (Some values are also used in tests:
+    - tests/unit/test_config.py
+    - tests/unit/test_actions.py
+    - tests/unit/test_base_git.py
+    - tests/integration/test_base_git.py
+    """
+
+    post_upstream_clone = "post-upstream-clone"
+    pre_sync = "pre-sync"
+    create_patches = "create-patches"
+    prepare_files = "prepare-files"
+    create_archive = "create-archive"
+    get_current_version = "get-current-version"
+
+    @classmethod
+    def is_valid_action(cls, action: str) -> bool:
+        return action in cls.get_possible_values()
+
+    @classmethod
+    def get_action_from_name(cls, action: str) -> Optional["ActionName"]:
+        if not cls.is_valid_action(action):
+            return None
+        return ActionName(action)
+
+    @classmethod
+    def get_possible_values(cls):
+        return [a.value for a in ActionName]

--- a/packit/api.py
+++ b/packit/api.py
@@ -73,7 +73,7 @@ class PackitAPI:
         return self._dg
 
     def sync_pr(self, pr_id, dist_git_branch: str, upstream_version: str = None):
-        self.package_config.run_action(action_name="pre-sync")
+        self.up.run_action(action_name="pre-sync")
 
         self.up.checkout_pr(pr_id=pr_id)
         local_pr_branch = f"pull-request-{pr_id}-sync"
@@ -90,7 +90,7 @@ class PackitAPI:
         self.dg.create_branch(local_pr_branch)
         self.dg.checkout_branch(local_pr_branch)
 
-        if self.package_config.with_action(action_name="patch"):
+        if self.up.with_action(action_name="patch"):
             patches = self.up.create_patches(
                 upstream=upstream_version, destination=self.dg.local_project.working_dir
             )
@@ -130,7 +130,7 @@ class PackitAPI:
         assert_existence(self.up.local_project)
         assert_existence(self.dg.local_project)
 
-        self.package_config.run_action(action_name="pre-sync")
+        self.up.run_action(action_name="pre-sync")
 
         full_version = version or self.up.get_version()
         if not full_version:
@@ -168,14 +168,14 @@ class PackitAPI:
                 f"Upstream commit: {self.up.local_project.git_repo.head.commit}\n"
             )
 
-            if self.package_config.with_action(action_name="prepare-files"):
+            if self.up.with_action(action_name="prepare-files"):
                 sync_files(
                     self.package_config,
                     self.up.local_project.working_dir,
                     self.dg.local_project.working_dir,
                 )
                 if upstream_ref:
-                    if self.package_config.with_action(action_name="patch"):
+                    if self.up.with_action(action_name="patch"):
                         patches = self.up.create_patches(
                             upstream=upstream_ref,
                             destination=self.dg.local_project.working_dir,
@@ -186,7 +186,7 @@ class PackitAPI:
                     add_new_sources=True, force_new_sources=force_new_sources
                 )
 
-            if self.package_config.has_action("prepare-files"):
+           if self.up.has_action("prepare-files"):
                 sync_files(
                     self.package_config,
                     self.up.local_project.working_dir,

--- a/packit/api.py
+++ b/packit/api.py
@@ -186,7 +186,7 @@ class PackitAPI:
                     add_new_sources=True, force_new_sources=force_new_sources
                 )
 
-           if self.up.has_action("prepare-files"):
+            if self.up.has_action("prepare-files"):
                 sync_files(
                     self.package_config,
                     self.up.local_project.working_dir,

--- a/packit/api.py
+++ b/packit/api.py
@@ -130,7 +130,7 @@ class PackitAPI:
         assert_existence(self.up.local_project)
         assert_existence(self.dg.local_project)
 
-        self.up.run_action(action_name="pre-sync")
+        self.up.run_action(action_name="init")
 
         full_version = version or self.up.get_version()
         if not full_version:
@@ -146,6 +146,8 @@ class PackitAPI:
             #       release = 232, tag = v232
             if not use_local_content:
                 self.up.checkout_release(full_version)
+
+            self.up.run_action(action_name="pre-sync")
 
             local_pr_branch = f"{full_version}-{dist_git_branch}-update"
             # fetch and reset --hard upstream/$branch?

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -27,6 +27,7 @@ import git
 from rebasehelper.specfile import SpecFile
 
 from packit import utils
+from packit.actions import ActionName
 from packit.config import Config, PackageConfig
 from packit.exceptions import PackitException
 from packit.local_project import LocalProject
@@ -122,7 +123,7 @@ class PackitRepositoryBase:
         # TODO: make -s configurable
         self.local_project.git_repo.git.commit(*commit_args)
 
-    def run_action(self, action_name: str, method: Callable = None, *args, **kwargs):
+    def run_action(self, action: ActionName, method: Callable = None, *args, **kwargs):
         """
         Run the method in the self._with_action block.
 
@@ -138,7 +139,7 @@ class PackitRepositoryBase:
         >   self._run_action(action_name="pre-sync")
         >   # This will be used as an optional hook
 
-        :param action_name: action_name: str (Name of the action that can be overwritten
+        :param action: ActionName enum (Name of the action that can be overwritten
                                                 in the package_config.actions)
         :param method: method to run if the action was not defined by user
                     (if not specified, the action can be used for custom hooks)
@@ -146,18 +147,18 @@ class PackitRepositoryBase:
         :param kwargs: kwargs for the method
         """
         if not method:
-            logger.debug(f"Running {action_name} hook.")
-        if self.with_action(action_name=action_name):
+            logger.debug(f"Running {action} hook.")
+        if self.with_action(action=action):
             if method:
                 method(*args, **kwargs)
 
-    def has_action(self, action_name: str) -> bool:
+    def has_action(self, action: ActionName) -> bool:
         """
         Is the action defined in the config?
         """
-        return action_name in self.package_config.actions
+        return action in self.package_config.actions
 
-    def with_action(self, action_name: str) -> bool:
+    def with_action(self, action: ActionName) -> bool:
         """
         If the action is defined in the self.package_config.actions,
         we run it and return False (so we can skip the if block)
@@ -175,26 +176,26 @@ class PackitRepositoryBase:
         https://stackoverflow.com/questions/12594148/skipping-execution-of-with-block
         https://www.python.org/dev/peps/pep-0377/ (rejected)
 
-        :param action_name: str (Name of the action that can be overwritten
+        :param action: ActionName enum (Name of the action that can be overwritten
                                                 in the package_config.actions)
         :return: True, if the action is not overwritten, False when custom command was run
         """
-        logger.debug(f"Running {action_name}.")
-        if action_name in self.package_config.actions:
-            command = self.package_config.actions[action_name]
-            logger.info(f"Using user-defined script for {action_name}: {command}")
+        logger.debug(f"Running {action}.")
+        if action in self.package_config.actions:
+            command = self.package_config.actions[action]
+            logger.info(f"Using user-defined script for {action}: {command}")
             utils.run_command(cmd=command, cwd=self.local_project.working_dir)
             return False
-        logger.debug(f"Running default implementation for {action_name}.")
+        logger.debug(f"Running default implementation for {action}.")
         return True
 
-    def get_output_from_action(self, action_name: str):
+    def get_output_from_action(self, action: ActionName):
         """
         Run action if specified in the self.actions and return output
         else return None
         """
-        if action_name in self.package_config.actions:
-            command = self.package_config.actions[action_name]
-            logger.info(f"Using user-defined script for {action_name}: {command}")
+        if action in self.package_config.actions:
+            command = self.package_config.actions[action]
+            logger.info(f"Using user-defined script for {action}: {command}")
             return run_command(cmd=command, output=True)
         return None

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -20,11 +20,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import git
 import logging
 from typing import Optional, Callable
 
+import git
 from rebasehelper.specfile import SpecFile
+
+from packit import utils
 from packit.config import Config, PackageConfig
 from packit.exceptions import PackitException
 from packit.local_project import LocalProject
@@ -181,7 +183,7 @@ class PackitRepositoryBase:
         if action_name in self.package_config.actions:
             command = self.package_config.actions[action_name]
             logger.info(f"Using user-defined script for {action_name}: {command}")
-            run_command(cmd=command)
+            utils.run_command(cmd=command, cwd=self.local_project.working_dir)
             return False
         logger.debug(f"Running default implementation for {action_name}.")
         return True

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -22,12 +22,13 @@
 
 import git
 import logging
-from typing import Optional
+from typing import Optional, Callable
 
 from rebasehelper.specfile import SpecFile
 from packit.config import Config, PackageConfig
 from packit.exceptions import PackitException
 from packit.local_project import LocalProject
+from packit.utils import run_command
 
 logger = logging.getLogger(__name__)
 
@@ -118,3 +119,80 @@ class PackitRepositoryBase:
         #       distribute it to the container, prepare git config and then we can start signing
         # TODO: make -s configurable
         self.local_project.git_repo.git.commit(*commit_args)
+
+    def run_action(self, action_name: str, method: Callable = None, *args, **kwargs):
+        """
+        Run the method in the self._with_action block.
+
+        Usage:
+
+        >   self._run_action(
+        >        action_name="sync", method=dg.sync_files, upstream_project=up.local_project
+        >   )
+        >   # If user provided custom command for the `sync`, it will be used.
+        >   # Otherwise, the method `dg.sync_files` will be used
+        >   # with parameter `upstream_project=up.local_project`
+        >
+        >   self._run_action(action_name="pre-sync")
+        >   # This will be used as an optional hook
+
+        :param action_name: action_name: str (Name of the action that can be overwritten
+                                                in the package_config.actions)
+        :param method: method to run if the action was not defined by user
+                    (if not specified, the action can be used for custom hooks)
+        :param args: args for the method
+        :param kwargs: kwargs for the method
+        """
+        if not method:
+            logger.debug(f"Running {action_name} hook.")
+        if self.with_action(action_name=action_name):
+            if method:
+                method(*args, **kwargs)
+
+    def has_action(self, action_name: str) -> bool:
+        """
+        Is the action defined in the config?
+        """
+        return action_name in self.package_config.actions
+
+    def with_action(self, action_name: str) -> bool:
+        """
+        If the action is defined in the self.package_config.actions,
+        we run it and return False (so we can skip the if block)
+
+        If the action is not defined, return True.
+
+        Usage:
+
+        >   if self._with_action(action_name="patch"):
+        >       # Run default implementation
+        >
+        >   # Custom command was run if defined in the config
+
+        Context manager is currently not possible without ugly hacks:
+        https://stackoverflow.com/questions/12594148/skipping-execution-of-with-block
+        https://www.python.org/dev/peps/pep-0377/ (rejected)
+
+        :param action_name: str (Name of the action that can be overwritten
+                                                in the package_config.actions)
+        :return: True, if the action is not overwritten, False when custom command was run
+        """
+        logger.debug(f"Running {action_name}.")
+        if action_name in self.package_config.actions:
+            command = self.package_config.actions[action_name]
+            logger.info(f"Using user-defined script for {action_name}: {command}")
+            run_command(cmd=command)
+            return False
+        logger.debug(f"Running default implementation for {action_name}.")
+        return True
+
+    def get_output_from_action(self, action_name: str):
+        """
+        Run action if specified in the self.actions and return output
+        else return None
+        """
+        if action_name in self.package_config.actions:
+            command = self.package_config.actions[action_name]
+            logger.info(f"Using user-defined script for {action_name}: {command}")
+            return run_command(cmd=command, output=True)
+        return None

--- a/packit/config.py
+++ b/packit/config.py
@@ -26,8 +26,7 @@ import os
 from enum import IntEnum
 from functools import lru_cache
 from pathlib import Path
-
-from typing import Optional, List, NamedTuple, Dict, Callable
+from typing import Optional, List, NamedTuple, Dict
 
 import click
 import jsonschema
@@ -37,7 +36,7 @@ from yaml import safe_load
 from ogr.abstract import GitProject
 from packit.constants import CONFIG_FILE_NAMES
 from packit.exceptions import PackitConfigException, PackitException
-from packit.utils import exclude_from_dict, run_command
+from packit.utils import exclude_from_dict
 
 logger = logging.getLogger(__name__)
 
@@ -371,83 +370,6 @@ class PackageConfig:
     @classmethod
     def validate_dict(cls, raw_dict: dict) -> None:
         jsonschema.validate(raw_dict, PACKAGE_CONFIG_SCHEMA)
-
-    def run_action(self, action_name: str, method: Callable = None, *args, **kwargs):
-        """
-        Run the method in the self._with_action block.
-
-        Usage:
-
-        >   self._run_action(
-        >        action_name="sync", method=dg.sync_files, upstream_project=up.local_project
-        >   )
-        >   # If user provided custom command for the `sync`, it will be used.
-        >   # Otherwise, the method `dg.sync_files` will be used
-        >   # with parameter `upstream_project=up.local_project`
-        >
-        >   self._run_action(action_name="pre-sync")
-        >   # This will be used as an optional hook
-
-        :param action_name: action_name: str (Name of the action that can be overwritten
-                                                in the package_config.actions)
-        :param method: method to run if the action was not defined by user
-                    (if not specified, the action can be used for custom hooks)
-        :param args: args for the method
-        :param kwargs: kwargs for the method
-        """
-        if not method:
-            logger.debug(f"Running {action_name} hook.")
-        if self.with_action(action_name=action_name):
-            if method:
-                method(*args, **kwargs)
-
-    def has_action(self, action_name: str) -> bool:
-        """
-        Is the action defined in the config?
-        """
-        return action_name in self.actions
-
-    def with_action(self, action_name: str) -> bool:
-        """
-        If the action is defined in the self.package_config.actions,
-        we run it and return False (so we can skip the if block)
-
-        If the action is not defined, return True.
-
-        Usage:
-
-        >   if self._with_action(action_name="patch"):
-        >       # Run default implementation
-        >
-        >   # Custom command was run if defined in the config
-
-        Context manager is currently not possible without ugly hacks:
-        https://stackoverflow.com/questions/12594148/skipping-execution-of-with-block
-        https://www.python.org/dev/peps/pep-0377/ (rejected)
-
-        :param action_name: str (Name of the action that can be overwritten
-                                                in the package_config.actions)
-        :return: True, if the action is not overwritten, False when custom command was run
-        """
-        logger.debug(f"Running {action_name}.")
-        if action_name in self.actions:
-            command = self.actions[action_name]
-            logger.info(f"Using user-defined script for {action_name}: {command}")
-            run_command(cmd=command)
-            return False
-        logger.debug(f"Running default implementation for {action_name}.")
-        return True
-
-    def get_output_from_action(self, action_name: str):
-        """
-        Run action if specified in the self.actions and return output
-        else return None
-        """
-        if action_name in self.actions:
-            command = self.actions[action_name]
-            logger.info(f"Using user-defined script for {action_name}: {command}")
-            return run_command(cmd=command, output=True)
-        return None
 
 
 def get_local_package_config(

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -22,7 +22,6 @@
 
 import logging
 import os
-import shutil
 from typing import Optional, List, Tuple, Sequence
 
 import git
@@ -30,12 +29,11 @@ import requests
 from rebasehelper.specfile import SpecFile
 
 from ogr.services.pagure import PagureService
+from packit.base_git import PackitRepositoryBase
 from packit.config import Config, PackageConfig, SyncFilesConfig
 from packit.exceptions import PackitException
-from packit.local_project import LocalProject
-
 from packit.fedpkg import FedPKG
-from packit.base_git import PackitRepositoryBase
+from packit.local_project import LocalProject
 
 logger = logging.getLogger(__name__)
 

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -22,6 +22,7 @@
 
 import logging
 import os
+import shutil
 from typing import Optional, List, Tuple, Sequence
 
 import git

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -34,6 +34,7 @@ from rebasehelper.specfile import SpecFile
 from rebasehelper.versioneer import versioneers_runner
 
 from ogr.services.github import GithubService
+from packit.actions import ActionName
 from packit.base_git import PackitRepositoryBase
 from packit.config import Config, PackageConfig, SyncFilesConfig
 from packit.exceptions import PackitException
@@ -355,7 +356,9 @@ class Upstream(PackitRepositoryBase):
 
         :return: e.g. 0.1.1.dev86+ga17a559.d20190315 or 0.6.1.1.gce4d84e
         """
-        action_output = self.get_output_from_action(action_name="get-current-version")
+        action_output = self.get_output_from_action(
+            action=ActionName.get_current_version
+        )
         if action_output:
             return action_output
 
@@ -413,7 +416,7 @@ class Upstream(PackitRepositoryBase):
         repository, only committed changes are present in the archive
         """
 
-        if self.with_action(action_name="create-archive"):
+        if self.with_action(action=ActionName.create_archive):
 
             if self.package_config.upstream_project_name:
                 dir_name = (

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -23,6 +23,7 @@
 import logging
 import os
 import re
+import shutil
 from pathlib import Path
 from typing import Optional, List, Tuple
 from packaging import version
@@ -355,9 +356,7 @@ class Upstream(PackitRepositoryBase):
 
         :return: e.g. 0.1.1.dev86+ga17a559.d20190315 or 0.6.1.1.gce4d84e
         """
-        action_output = self.package_config.get_output_from_action(
-            action_name="get-current-version"
-        )
+        action_output = self.get_output_from_action(action_name="get-current-version")
         if action_output:
             return action_output
 
@@ -415,7 +414,7 @@ class Upstream(PackitRepositoryBase):
         repository, only committed changes are present in the archive
         """
 
-        if self.package_config.with_action(action_name="create-archive"):
+        if self.with_action(action_name="create-archive"):
 
             if self.package_config.upstream_project_name:
                 dir_name = (

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -23,23 +23,22 @@
 import logging
 import os
 import re
-import shutil
 from pathlib import Path
 from typing import Optional, List, Tuple
-from packaging import version
 
 import git
 import github
-from ogr.services.github import GithubService
+from packaging import version
 from rebasehelper.exceptions import RebaseHelperError
 from rebasehelper.specfile import SpecFile
 from rebasehelper.versioneer import versioneers_runner
 
+from ogr.services.github import GithubService
+from packit.base_git import PackitRepositoryBase
 from packit.config import Config, PackageConfig, SyncFilesConfig
 from packit.exceptions import PackitException
 from packit.local_project import LocalProject
 from packit.utils import run_command
-from packit.base_git import PackitRepositoryBase
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/test_base_git.py
+++ b/tests/integration/test_base_git.py
@@ -1,5 +1,6 @@
 from flexmock import flexmock
 
+from packit.actions import ActionName
 from packit.base_git import PackitRepositoryBase
 from packit.config import PackageConfig
 
@@ -9,10 +10,10 @@ def test_get_output_from_action_defined():
 
     packit_repository_base = PackitRepositoryBase(
         config=flexmock(),
-        package_config=flexmock(PackageConfig(actions={"action-a": echo_cmd})),
+        package_config=flexmock(PackageConfig(actions={ActionName.pre_sync: echo_cmd})),
     )
 
     packit_repository_base.local_project = flexmock(working_dir=".")
 
-    result = packit_repository_base.get_output_from_action("action-a")
+    result = packit_repository_base.get_output_from_action(ActionName.pre_sync)
     assert result == "hello world\n"

--- a/tests/integration/test_base_git.py
+++ b/tests/integration/test_base_git.py
@@ -1,0 +1,18 @@
+import pytest
+from flexmock import flexmock
+
+from tests.unit.test_base_git import distgit_with_actions, upstream_with_actions
+
+
+@pytest.mark.parametrize(
+    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
+)
+def test_get_output_from_action_defined(base_git_fixture):
+    echo_cmd = "echo 'hello world'"
+
+    base_git = base_git_fixture()
+    base_git._local_project = flexmock(working_dir=".")
+    base_git.package_config.actions = {"action-a": echo_cmd}
+
+    result = base_git.get_output_from_action("action-a")
+    assert result == "hello world\n"

--- a/tests/integration/test_base_git.py
+++ b/tests/integration/test_base_git.py
@@ -1,18 +1,18 @@
-import pytest
 from flexmock import flexmock
 
-from tests.unit.test_base_git import distgit_with_actions, upstream_with_actions
+from packit.base_git import PackitRepositoryBase
+from packit.config import PackageConfig
 
 
-@pytest.mark.parametrize(
-    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
-)
-def test_get_output_from_action_defined(base_git_fixture):
+def test_get_output_from_action_defined():
     echo_cmd = "echo 'hello world'"
 
-    base_git = base_git_fixture()
-    base_git._local_project = flexmock(working_dir=".")
-    base_git.package_config.actions = {"action-a": echo_cmd}
+    packit_repository_base = PackitRepositoryBase(
+        config=flexmock(),
+        package_config=flexmock(PackageConfig(actions={"action-a": echo_cmd})),
+    )
 
-    result = base_git.get_output_from_action("action-a")
+    packit_repository_base.local_project = flexmock(working_dir=".")
+
+    result = packit_repository_base.get_output_from_action("action-a")
     assert result == "hello world\n"

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -1,0 +1,59 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+
+from packit.actions import ActionName
+
+
+@pytest.mark.parametrize(
+    "action,valid",
+    [
+        ("get-current-version", True),
+        ("create-patches", True),
+        ("unknown-action", False),
+        ("create_patches", False),
+    ],
+)
+def test_is_valid(action, valid):
+    assert ActionName.is_valid_action(action) == valid
+
+
+def test_get_possible_values():
+    values = ActionName.get_possible_values()
+    assert values
+    assert isinstance(values, list)
+    for action_value in values:
+        assert isinstance(action_value, str)
+        assert "_" not in action_value
+
+
+@pytest.mark.parametrize(
+    "action_name,result",
+    [
+        ("get-current-version", ActionName.get_current_version),
+        ("create-patches", ActionName.create_patches),
+        ("unknown-action", None),
+        ("create_patches", None),
+    ],
+)
+def test_get_action_from_name(action_name, result):
+    assert ActionName.get_action_from_name(action_name) == result

--- a/tests/unit/test_base_git.py
+++ b/tests/unit/test_base_git.py
@@ -5,6 +5,7 @@ from packit import utils
 from packit.base_git import PackitRepositoryBase
 from packit.config import PackageConfig, Config
 from packit.distgit import DistGit
+from packit.upstream import Upstream
 
 
 @pytest.fixture()
@@ -21,13 +22,14 @@ def distgit_with_actions():
 
 @pytest.fixture()
 def upstream_with_actions():
-    return DistGit(
+    return Upstream(
         config=flexmock(Config()),
         package_config=flexmock(
             PackageConfig(
                 actions={"action-a": "command --a", "action-b": "command --b"}
             )
         ),
+        local_project=flexmock(repo_name=flexmock()),
     )
 
 

--- a/tests/unit/test_base_git.py
+++ b/tests/unit/test_base_git.py
@@ -1,0 +1,150 @@
+import pytest
+from flexmock import flexmock
+
+from packit import utils
+from packit.config import PackageConfig, Config
+from packit.distgit import DistGit
+
+
+@pytest.fixture()
+def distgit_with_actions():
+    return DistGit(
+        config=flexmock(Config()),
+        package_config=flexmock(
+            PackageConfig(
+                actions={"action-a": "command --a", "action-b": "command --b"}
+            )
+        ),
+    )
+
+
+@pytest.fixture()
+def upstream_with_actions():
+    return DistGit(
+        config=flexmock(Config()),
+        package_config=flexmock(
+            PackageConfig(
+                actions={"action-a": "command --a", "action-b": "command --b"}
+            )
+        ),
+    )
+
+
+def test_has_action_upstream(upstream_with_actions):
+    assert upstream_with_actions.has_action("action-a")
+    assert not upstream_with_actions.has_action("action-c")
+
+
+def test_has_action_distgit(distgit_with_actions):
+    assert distgit_with_actions.has_action("action-a")
+    assert not distgit_with_actions.has_action("action-c")
+
+
+@pytest.mark.parametrize(
+    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
+)
+def test_with_action_non_defined(base_git_fixture):
+    base_git = base_git_fixture()
+
+    if base_git.with_action(action_name="unknown-action"):
+        # this is the style we are using that function
+        return
+
+    assert False
+
+
+@pytest.mark.parametrize(
+    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
+)
+def test_with_action_defined(base_git_fixture):
+    flexmock(utils).should_receive("run_command").once()
+
+    base_git = base_git_fixture()
+    base_git._local_project = flexmock(working_dir="my/working/dir")
+
+    if base_git.with_action(action_name="action-a"):
+        # this is the style we are using that function
+        assert False
+
+
+@pytest.mark.parametrize(
+    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
+)
+def test_with_action_working_dir(base_git_fixture):
+    flexmock(utils).should_receive("run_command").with_args(
+        cmd="command --a", cwd="my/working/dir"
+    ).once()
+
+    base_git = base_git_fixture()
+    base_git._local_project = flexmock(working_dir="my/working/dir")
+
+    assert not base_git.with_action(action_name="action-a")
+
+
+@pytest.mark.parametrize(
+    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
+)
+def test_run_action_hook_not_defined(base_git_fixture):
+    flexmock(utils).should_receive("run_command").times(0)
+
+    base_git = base_git_fixture()
+    base_git._local_project = flexmock(working_dir="my/working/dir")
+
+    base_git.run_action(action_name="not-defined")
+
+
+@pytest.mark.parametrize(
+    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
+)
+def test_run_action_not_defined(base_git_fixture):
+    flexmock(utils).should_receive("run_command").times(0)
+
+    base_git = base_git_fixture()
+    base_git._local_project = flexmock(working_dir="my/working/dir")
+
+    action_method = (
+        flexmock()
+        .should_receive("action_function")
+        .with_args("arg", kwarg="kwarg")
+        .once()
+        .mock()
+        .action_function
+    )
+
+    base_git.run_action("not-defined", action_method, "arg", kwarg="kwarg")
+
+
+@pytest.mark.parametrize(
+    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
+)
+def test_run_action_defined(base_git_fixture):
+    flexmock(utils).should_receive("run_command").with_args(
+        cmd="command --a", cwd="my/working/dir"
+    ).once()
+
+    base_git = base_git_fixture()
+    base_git._local_project = flexmock(working_dir="my/working/dir")
+
+    action_method = (
+        flexmock()
+        .should_receive("action_function")
+        .with_args("arg", kwarg="kwarg")
+        .times(0)
+        .mock()
+        .action_function
+    )
+
+    base_git.run_action("action-a", action_method, "arg", kwarg="kwarg")
+
+
+@pytest.mark.parametrize(
+    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
+)
+def test_get_output_from_action_not_defined(base_git_fixture):
+    flexmock(utils).should_receive("run_command").times(0)
+
+    base_git = base_git_fixture()
+    base_git._local_project = flexmock(working_dir="my/working/dir")
+
+    result = base_git.get_output_from_action("not-defined")
+    assert result is None

--- a/tests/unit/test_base_git.py
+++ b/tests/unit/test_base_git.py
@@ -2,6 +2,7 @@ import pytest
 from flexmock import flexmock
 
 from packit import utils
+from packit.base_git import PackitRepositoryBase
 from packit.config import PackageConfig, Config
 from packit.distgit import DistGit
 
@@ -30,6 +31,18 @@ def upstream_with_actions():
     )
 
 
+@pytest.fixture()
+def packit_repository_base():
+    return PackitRepositoryBase(
+        config=flexmock(),
+        package_config=flexmock(
+            PackageConfig(
+                actions={"action-a": "command --a", "action-b": "command --b"}
+            )
+        ),
+    )
+
+
 def test_has_action_upstream(upstream_with_actions):
     assert upstream_with_actions.has_action("action-a")
     assert not upstream_with_actions.has_action("action-c")
@@ -40,67 +53,46 @@ def test_has_action_distgit(distgit_with_actions):
     assert not distgit_with_actions.has_action("action-c")
 
 
-@pytest.mark.parametrize(
-    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
-)
-def test_with_action_non_defined(base_git_fixture):
-    base_git = base_git_fixture()
-
-    if base_git.with_action(action_name="unknown-action"):
+def test_with_action_non_defined(packit_repository_base):
+    if packit_repository_base.with_action(action_name="unknown-action"):
         # this is the style we are using that function
         return
 
     assert False
 
 
-@pytest.mark.parametrize(
-    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
-)
-def test_with_action_defined(base_git_fixture):
+def test_with_action_defined(packit_repository_base):
     flexmock(utils).should_receive("run_command").once()
 
-    base_git = base_git_fixture()
-    base_git._local_project = flexmock(working_dir="my/working/dir")
+    packit_repository_base.local_project = flexmock(working_dir="my/working/dir")
 
-    if base_git.with_action(action_name="action-a"):
+    if packit_repository_base.with_action(action_name="action-a"):
         # this is the style we are using that function
         assert False
 
 
-@pytest.mark.parametrize(
-    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
-)
-def test_with_action_working_dir(base_git_fixture):
+def test_with_action_working_dir(packit_repository_base):
     flexmock(utils).should_receive("run_command").with_args(
         cmd="command --a", cwd="my/working/dir"
     ).once()
 
-    base_git = base_git_fixture()
-    base_git._local_project = flexmock(working_dir="my/working/dir")
+    packit_repository_base.local_project = flexmock(working_dir="my/working/dir")
 
-    assert not base_git.with_action(action_name="action-a")
+    assert not packit_repository_base.with_action(action_name="action-a")
 
 
-@pytest.mark.parametrize(
-    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
-)
-def test_run_action_hook_not_defined(base_git_fixture):
+def test_run_action_hook_not_defined(packit_repository_base):
     flexmock(utils).should_receive("run_command").times(0)
 
-    base_git = base_git_fixture()
-    base_git._local_project = flexmock(working_dir="my/working/dir")
+    packit_repository_base.local_project = flexmock(working_dir="my/working/dir")
 
-    base_git.run_action(action_name="not-defined")
+    packit_repository_base.run_action(action_name="not-defined")
 
 
-@pytest.mark.parametrize(
-    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
-)
-def test_run_action_not_defined(base_git_fixture):
+def test_run_action_not_defined(packit_repository_base):
     flexmock(utils).should_receive("run_command").times(0)
 
-    base_git = base_git_fixture()
-    base_git._local_project = flexmock(working_dir="my/working/dir")
+    packit_repository_base.local_project = flexmock(working_dir="my/working/dir")
 
     action_method = (
         flexmock()
@@ -111,19 +103,17 @@ def test_run_action_not_defined(base_git_fixture):
         .action_function
     )
 
-    base_git.run_action("not-defined", action_method, "arg", kwarg="kwarg")
+    packit_repository_base.run_action(
+        "not-defined", action_method, "arg", kwarg="kwarg"
+    )
 
 
-@pytest.mark.parametrize(
-    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
-)
-def test_run_action_defined(base_git_fixture):
+def test_run_action_defined(packit_repository_base):
     flexmock(utils).should_receive("run_command").with_args(
         cmd="command --a", cwd="my/working/dir"
     ).once()
 
-    base_git = base_git_fixture()
-    base_git._local_project = flexmock(working_dir="my/working/dir")
+    packit_repository_base.local_project = flexmock(working_dir="my/working/dir")
 
     action_method = (
         flexmock()
@@ -134,17 +124,13 @@ def test_run_action_defined(base_git_fixture):
         .action_function
     )
 
-    base_git.run_action("action-a", action_method, "arg", kwarg="kwarg")
+    packit_repository_base.run_action("action-a", action_method, "arg", kwarg="kwarg")
 
 
-@pytest.mark.parametrize(
-    "base_git_fixture", [distgit_with_actions, upstream_with_actions]
-)
-def test_get_output_from_action_not_defined(base_git_fixture):
+def test_get_output_from_action_not_defined(packit_repository_base):
     flexmock(utils).should_receive("run_command").times(0)
 
-    base_git = base_git_fixture()
-    base_git._local_project = flexmock(working_dir="my/working/dir")
+    packit_repository_base.local_project = flexmock(working_dir="my/working/dir")
 
-    result = base_git.get_output_from_action("not-defined")
+    result = packit_repository_base.get_output_from_action("not-defined")
     assert result is None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -28,6 +28,7 @@ from flexmock import flexmock
 from jsonschema.exceptions import ValidationError
 from os import chdir
 
+from packit.actions import ActionName
 from tests.spellbook import TESTS_DIR
 from ogr.abstract import GitProject, GitService
 from packit.config import (
@@ -280,7 +281,7 @@ def test_package_config_not_equal(not_equal_package_config):
                 "synced_files": ["fedora/foobar.spec"],
                 "actions": {
                     "pre-sync": "some/pre-sync/command --option",
-                    "upstream-version": "get-me-upstream-version",
+                    "get-current-version": "get-me-version",
                 },
                 "jobs": [
                     {"trigger": "release", "release_to": ["f28"]},
@@ -289,6 +290,22 @@ def test_package_config_not_equal(not_equal_package_config):
                 ],
             },
             True,
+        ),
+        (
+            {
+                "specfile_path": "fedora/package.spec",
+                "synced_files": ["fedora/foobar.spec"],
+                "actions": {
+                    "pre-sync": "some/pre-sync/command --option",
+                    "unknown-action": "nothing",
+                },
+                "jobs": [
+                    {"trigger": "release", "release_to": ["f28"]},
+                    {"trigger": "pull_request", "release_to": ["f29", "f30", "master"]},
+                    {"trigger": "git_tag", "release_to": ["f29", "f30", "master"]},
+                ],
+            },
+            False,
         ),
         (
             {
@@ -462,7 +479,7 @@ def test_package_config_parse_error(raw):
                 "synced_files": [],
                 "actions": {
                     "pre-sync": "some/pre-sync/command --option",
-                    "upstream-version": "get-me-upstream-version",
+                    "get-current-version": "get-me-version",
                 },
                 "jobs": [],
                 "something": "stupid",
@@ -473,8 +490,8 @@ def test_package_config_parse_error(raw):
             PackageConfig(
                 specfile_path="fedora/package.spec",
                 actions={
-                    "pre-sync": "some/pre-sync/command --option",
-                    "upstream-version": "get-me-upstream-version",
+                    ActionName.pre_sync: "some/pre-sync/command --option",
+                    ActionName.get_current_version: "get-me-version",
                 },
                 synced_files=SyncFilesConfig(files_to_sync=None),
                 jobs=[],


### PR DESCRIPTION
Follow-up for #213 

- [x] Get support for actions in the PackageConfig. (#213)
- [x] loading + validation of the actions (#213)
- [x] Move methods for actions to base class for Upstream/Distgit.
- [x] Use enum for action names
- [ ] support acctions in `propose-update` (partialy in #213)
    - [ ] be sure it works for the kernel workflow
    - [x] be sure it can work for the pykickstart (Resolves #194 )
- [ ] be sure that `raw` source-git works (without actions)
- [x] tests
- [x] docs

-----

### Action/hook table from docs

|        | name                  | working directory | when run                                                                          | description                               |
| ------ | --------------------- | ----------------- | --------------------------------------------------------------------------------  | ----------------------------------------- |
| [hook] | `post-upstream-clone` | upstream git repo | after cloning of the upstream-repo (master) and before other operation            |                                           |
| [hook] | `pre-sync`            | upstream git repo | after cloning of the upstream-repo and checkout to the right (release) branch     |                                           |
|        | `prepare-files`       | upstream git repo | after clone and checkout of upstream and dist-git repo                            | replace patching and archive generation   |
|        | `create-patches`      | upstream git repo | after sync of upstream files to the downstream                                    | replace patching                          |
|        | `create-archive`      | upstream git repo | when the archive needs to be created                                              | replace the code for creating an archive  |
|        | `get-current-version` | upstream git repo | when the current version needs to be found                                        | expect version as a stdout                |

