### PR TITLE
containerized tests: comment out and document

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,13 @@ check-pypi-packaging:
 build-tests: recipe-tests.yaml
 	ansible-bender build -- ./recipe-tests.yaml $(SOURCE_GIT_IMAGE) $(PACKIT_TESTS_IMAGE)
 
-# FIXME: is not working ATM
-test-in-container:
-	podman run --rm -ti -v $(CURDIR):/src:Z -w /src $(PACKIT_TESTS_IMAGE) make check
+shell:
+	podman run --rm -ti -v $(CURDIR):/src:Z -w /src $(PACKIT_TESTS_IMAGE) bash
+
+# we should probably run tests in a root container (sudo podman)
+# getting these type of errors with rootless:
+#   error: [Errno 13] Permission denied: '/src/.tox/py36/lib/python3.6/site-packages/rpm-4.14.2.1-py3.6-linux-x86_64.egg'
+# even though it doesn't make any sense: after tox fails, I can access the file
+# just fine: a bug in fuse-overlayfs?
+# test-in-container:
+# 	podman run --rm -ti -v $(CURDIR):/src:Z -w /src $(PACKIT_TESTS_IMAGE) make check

--- a/recipe-tests.yaml
+++ b/recipe-tests.yaml
@@ -1,6 +1,15 @@
 ---
 - name: This is a recipe for a container image where packit tests will run
   hosts: all
+  vars:
+    ansible_bender:
+      target_image:
+        environment:
+          LD_PRELOAD: ""
+          NSS_WRAPPER_PASSWD: ""
+          NSS_WRAPPER_GROUP: /etc/group
+          USER: ""
+          HOME: ""
   tasks:
   - name: Install all packages needed to run tests
     dnf:
@@ -10,4 +19,8 @@
       - krb5-devel
       - rpm-libs
       - redhat-rpm-config
+      # when running the tests in a rootless podman container, tox environment
+      # needed gcc and rpm-devel to compile the rpm-libs python bindings
+      # - gcc
+      # - rpm-devel
       state: present

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -33,6 +33,8 @@
       - python3-ipdb  # for easy debugging
       - python3-fedmsg
       - python3-pyyaml
+      - python3-rpm
+      - python3-GitPython
       - python3-requests
       - python3-pygithub
       - python3-libpagure


### PR DESCRIPTION
and also:

* recipe-tests: attempt a fix
  * that NSS wrapper is for sake of openshift: anyuid and rootless are not
    compatible
  * gcc and rpm-devel are needed for rpm python bindings
* recipe: install more content from RPM