### PR TITLE
Random fixes (which we need)

### DIFF
--- a/docs/how-to-source-git.md
+++ b/docs/how-to-source-git.md
@@ -165,7 +165,8 @@ bcc2c8a292 resolved: create /etc/resolv.conf symlink at runtime
 1d39b39df9 Revert "journald: periodically drop cache for all dead PIDs"
 ```
 
-And that's it, this is our source-git repo!
+And that's it, this is our source-git repo! You can check it out over
+[here](https://github.com/packit-service/systemd-source-git).
 
 Once we finish source-git related code in packit, you'd be able then to work
 exclusively in source-git, getting results from tests and other testing systems

--- a/packit/config.py
+++ b/packit/config.py
@@ -179,7 +179,7 @@ class SyncFilesItem(NamedTuple):
     dest: str
 
     def __repr__(self):
-        return f"[src={self.src}, dest={self.dest}]"
+        return f"SyncFilesItem(src={self.src}, dest={self.dest})"
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SyncFilesItem):
@@ -193,7 +193,7 @@ class SyncFilesConfig:
         self.files_to_sync = files_to_sync
 
     def __repr__(self):
-        return f"{self.files_to_sync!r}"
+        return f"SyncFilesConfig({self.files_to_sync!r})"
 
     @classmethod
     def get_from_dict(cls, raw_dict: dict, validate=True) -> "SyncFilesConfig":

--- a/packit/config.py
+++ b/packit/config.py
@@ -254,7 +254,7 @@ class PackageConfig:
         actions: Dict[ActionName, str] = None,
     ):
         self.specfile_path: Optional[str] = specfile_path
-        self.synced_files: Optional[SyncFilesConfig] = synced_files or None
+        self.synced_files: SyncFilesConfig = synced_files or SyncFilesConfig([])
         self.jobs: List[JobConfig] = jobs or []
         self.dist_git_namespace: str = dist_git_namespace or "rpms"
         self.upstream_project_url: Optional[str] = upstream_project_url
@@ -315,7 +315,6 @@ class PackageConfig:
         if validate:
             PackageConfig.validate_dict(raw_dict)
 
-        specfile_path = raw_dict.get("specfile_path", None)
         synced_files = raw_dict.get("synced_files", None)
         actions = raw_dict.get("actions", {})
         raw_jobs = raw_dict.get("jobs", [])
@@ -335,6 +334,18 @@ class PackageConfig:
         downstream_package_name = cls.get_deprecated_key(
             raw_dict, "downstream_package_name", "package_name"
         )
+        specfile_path = raw_dict.get("specfile_path", None)
+        if specfile_path:
+            specfile_path = str(Path(specfile_path).resolve())
+        else:
+            if downstream_package_name:
+                specfile_path = str(
+                    Path.cwd().joinpath(f"{downstream_package_name}.spec")
+                )
+                logger.info(f"We guess that spec file is at {specfile_path}")
+            else:
+                # guess it?
+                logger.warning("Path to spec file is not set.")
 
         dist_git_base_url = raw_dict.get("dist_git_base_url", None)
         dist_git_namespace = raw_dict.get("dist_git_namespace", None)

--- a/packit/config.py
+++ b/packit/config.py
@@ -280,7 +280,7 @@ class PackageConfig:
                 "describe",
                 "--tags",
                 "--match",
-                "*.*",
+                "*",
             ]
 
     def __eq__(self, other: object):

--- a/packit/config.py
+++ b/packit/config.py
@@ -501,7 +501,7 @@ PACKAGE_CONFIG_SCHEMA = {
             "additionalProperties": False,
         },
     },
-    "required": ["specfile_path", "synced_files"],
+    "required": ["specfile_path"],
 }
 
 USER_CONFIG_SCHEMA = {

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -69,12 +69,8 @@ class Upstream(PackitRepositoryBase):
         return self.local_project.ref
 
     @property
-    def specfile_path(self) -> Optional[str]:
-        if self.package_name:
-            return os.path.join(
-                self.local_project.working_dir, f"{self.package_name}.spec"
-            )
-        return None
+    def specfile_path(self) -> str:
+        return self.package_config.specfile_path
 
     def set_local_project(self):
         """ update self.local_project """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 import datetime
+import os
 import shutil
 import subprocess
 import sys
@@ -197,6 +198,9 @@ def downstream_n_distgit(tmpdir):
 def upstream_instance(upstream_n_distgit):
     u, d = upstream_n_distgit
 
+    # we need to chdir(u) because when PackageConfig is created,
+    # it already expects it's in the correct directory
+    old_cwd = os.getcwd()
     chdir(u)
     c = get_test_config()
 
@@ -206,7 +210,8 @@ def upstream_instance(upstream_n_distgit):
     lp = LocalProject(path_or_url=str(u))
 
     ups = Upstream(c, pc, lp)
-    return u, ups
+    yield u, ups
+    chdir(old_cwd)
 
 
 @pytest.fixture()
@@ -224,6 +229,9 @@ def distgit_instance(upstream_n_distgit, mock_upstream_remote_functionality):
 def api_instance(upstream_n_distgit):
     u, d = upstream_n_distgit
 
+    # we need to chdir(u) because when PackageConfig is created,
+    # it already expects it's in the correct directory
+    old_cwd = os.getcwd()
     chdir(u)
     c = get_test_config()
 
@@ -232,4 +240,5 @@ def api_instance(upstream_n_distgit):
     up_lp = LocalProject(path_or_url=str(u))
 
     api = PackitAPI(c, pc, up_lp)
-    return u, d, api
+    yield u, d, api
+    chdir(old_cwd)

--- a/tests/integration/test_build.py
+++ b/tests/integration/test_build.py
@@ -20,23 +20,23 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from os import chdir
-
 from packit.api import PackitAPI
 from packit.config import get_local_package_config
 from packit.local_project import LocalProject
 from tests.spellbook import get_test_config
+from tests.utils import cwd
 
 
 def test_basic_build(upstream_n_distgit, mock_upstream_remote_functionality):
     u, d = upstream_n_distgit
-    chdir(u)
-    c = get_test_config()
 
-    pc = get_local_package_config(str(u))
-    pc.upstream_project_url = str(u)
-    pc.downstream_project_url = str(d)
-    up_lp = LocalProject(path_or_url=u)
+    with cwd(u):
+        c = get_test_config()
 
-    api = PackitAPI(c, pc, up_lp)
-    api.build("master")
+        pc = get_local_package_config(str(u))
+        pc.upstream_project_url = str(u)
+        pc.downstream_project_url = str(d)
+        up_lp = LocalProject(path_or_url=u)
+
+        api = PackitAPI(c, pc, up_lp)
+        api.build("master")

--- a/tests/integration/test_create_update.py
+++ b/tests/integration/test_create_update.py
@@ -20,8 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from os import chdir
-
 import pytest
 from flexmock import flexmock
 from munch import Munch
@@ -30,6 +28,7 @@ from packit.api import PackitAPI
 from packit.config import get_local_package_config
 from packit.local_project import LocalProject
 from tests.spellbook import get_test_config, can_a_module_be_imported
+from tests.utils import cwd
 
 
 @pytest.fixture()
@@ -294,37 +293,37 @@ def test_basic_bodhi_update(
     from bodhi.client.bindings import BodhiClient
 
     u, d = upstream_n_distgit
-    chdir(u)
-    c = get_test_config()
+    with cwd(u):
+        c = get_test_config()
 
-    pc = get_local_package_config(str(u))
-    pc.upstream_project_url = str(u)
-    pc.downstream_project_url = str(d)
-    up_lp = LocalProject(path_or_url=u)
+        pc = get_local_package_config(str(u))
+        pc.upstream_project_url = str(u)
+        pc.downstream_project_url = str(d)
+        up_lp = LocalProject(path_or_url=u)
 
-    api = PackitAPI(c, pc, up_lp)
+        api = PackitAPI(c, pc, up_lp)
 
-    flexmock(
-        BodhiClient,
-        latest_builds=lambda package: {
-            "f29-override": "sen-0.6.0-3.fc29",
-            "f29-updates": "sen-0.6.0-3.fc29",
-            "f29-updates-candidate": "sen-0.6.0-3.fc29",
-            "f29-updates-pending": "sen-0.6.0-3.fc29",
-            "f29-updates-testing": "sen-0.6.0-3.fc29",
-            "f29-updates-testing-pending": "sen-0.6.0-3.fc29",
-            "f30-override": "sen-0.6.0-4.fc30",
-            "f30-updates": "sen-0.6.0-4.fc30",
-            "f30-updates-candidate": "sen-0.6.1-1.fc30",
-            "f30-updates-pending": "sen-0.6.0-4.fc30",
-            "f30-updates-testing": "sen-0.6.0-4.fc30",
-            "f30-updates-testing-pending": "sen-0.6.0-4.fc30",
-        },
-        save=lambda **kwargs: bodhi_response,
-    )
-    api.create_update(
-        dist_git_branch=branch,
-        update_type=update_type,
-        update_notes=update_notes,
-        koji_builds=koji_builds,
-    )
+        flexmock(
+            BodhiClient,
+            latest_builds=lambda package: {
+                "f29-override": "sen-0.6.0-3.fc29",
+                "f29-updates": "sen-0.6.0-3.fc29",
+                "f29-updates-candidate": "sen-0.6.0-3.fc29",
+                "f29-updates-pending": "sen-0.6.0-3.fc29",
+                "f29-updates-testing": "sen-0.6.0-3.fc29",
+                "f29-updates-testing-pending": "sen-0.6.0-3.fc29",
+                "f30-override": "sen-0.6.0-4.fc30",
+                "f30-updates": "sen-0.6.0-4.fc30",
+                "f30-updates-candidate": "sen-0.6.1-1.fc30",
+                "f30-updates-pending": "sen-0.6.0-4.fc30",
+                "f30-updates-testing": "sen-0.6.0-4.fc30",
+                "f30-updates-testing-pending": "sen-0.6.0-4.fc30",
+            },
+            save=lambda **kwargs: bodhi_response,
+        )
+        api.create_update(
+            dist_git_branch=branch,
+            update_type=update_type,
+            update_notes=update_notes,
+            koji_builds=koji_builds,
+        )

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -21,8 +21,6 @@
 # SOFTWARE.
 
 import copy
-from os import chdir
-
 import git
 import pytest
 from flexmock import flexmock
@@ -35,6 +33,7 @@ from packit.config import get_local_package_config
 from packit.fed_mes_consume import Consumerino
 from packit.local_project import LocalProject
 from tests.spellbook import TARBALL_NAME, get_test_config
+from tests.utils import cwd
 
 
 @pytest.fixture()
@@ -67,19 +66,19 @@ def test_basic_local_update(upstream_n_distgit, mock_upstream_remote_functionali
     """ basic propose-update test: mock remote API, use local upstream and dist-git """
     u, d = upstream_n_distgit
 
-    chdir(u)
-    c = get_test_config()
+    with cwd(u):
+        c = get_test_config()
 
-    pc = get_local_package_config(str(u))
-    pc.upstream_project_url = str(u)
-    pc.downstream_project_url = str(d)
-    up_lp = LocalProject(path_or_url=str(u))
-    api = PackitAPI(c, pc, up_lp)
-    api.sync_release("master", "0.1.0")
+        pc = get_local_package_config(str(u))
+        pc.upstream_project_url = str(u)
+        pc.downstream_project_url = str(d)
+        up_lp = LocalProject(path_or_url=str(u))
+        api = PackitAPI(c, pc, up_lp)
+        api.sync_release("master", "0.1.0")
 
-    assert (d / TARBALL_NAME).is_file()
-    spec = SpecFile(str(d / "beer.spec"), None)
-    assert spec.get_version() == "0.1.0"
+        assert (d / TARBALL_NAME).is_file()
+        spec = SpecFile(str(d / "beer.spec"), None)
+        assert spec.get_version() == "0.1.0"
 
 
 def test_basic_local_update_from_downstream(
@@ -88,18 +87,18 @@ def test_basic_local_update_from_downstream(
     flexmock(LocalProject, _parse_namespace_from_git_url=lambda: None)
     u, d = downstream_n_distgit
 
-    chdir(u)
-    c = get_test_config()
-    pc = get_local_package_config(str(u))
-    pc.upstream_project_url = str(u)
-    pc.downstream_project_url = str(d)
-    up_lp = LocalProject(path_or_url=str(u))
-    api = PackitAPI(c, pc, up_lp)
-    api.sync_from_downstream("master", "master", True)
+    with cwd(u):
+        c = get_test_config()
+        pc = get_local_package_config(str(u))
+        pc.upstream_project_url = str(u)
+        pc.downstream_project_url = str(d)
+        up_lp = LocalProject(path_or_url=str(u))
+        api = PackitAPI(c, pc, up_lp)
+        api.sync_from_downstream("master", "master", True)
 
-    assert (u / "beer.spec").is_file()
-    spec = SpecFile(str(u / "beer.spec"), None)
-    assert spec.get_version() == "0.0.0"
+        assert (u / "beer.spec").is_file()
+        spec = SpecFile(str(u / "beer.spec"), None)
+        assert spec.get_version() == "0.0.0"
 
 
 def test_single_message(github_release_fedmsg, mock_upstream_remote_functionality):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,20 @@
+import os
+from contextlib import contextmanager
+
+
+@contextmanager
+def cwd(target):
+    """
+    Manage cwd in a pushd/popd fashion.
+
+    Usage:
+
+        with cwd(tmpdir):
+          do something in tmpdir
+    """
+    curdir = os.getcwd()
+    os.chdir(target)
+    try:
+        yield
+    finally:
+        os.chdir(curdir)


### PR DESCRIPTION
Based on top of #231

* ehm, actually use package_config.specfile_path

* git describe: use --match *

    I copied the command from the setuptools scm plugin w/o really knowing
    what it does. * is better, b/c we don't give a damn if there are dots in
    the tag.