### PR TITLE
Add wsgi script into Python path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     - id: flake8
       args:
         - --max-line-length=100
-        - --per-file-ignores=files/packit.wsgi:F401
+        - --per-file-ignores=files/packit.wsgi:F401,E402
 -   repo: https://github.com/ambv/black
     rev: stable
     hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,13 @@ COPY packit/ /src/packit/
 RUN cd /src/ \
     && ansible-playbook -vv -c local -i localhost, recipe.yaml
 
-ENV USER=packit \
-    HOME=/home/packit/ \
-    NSS_WRAPPER_PASSWD=/home/packit/passwd \
-    NSS_WRAPPER_GROUP=/etc/group \
-    LD_PRELOAD=libnss_wrapper.so \
-    FLASK_APP=packit.service.web_hook
+#COPY ./files/httpd-packit.conf /etc/httpd/conf.d/httpd-packit.conf
+
+RUN /usr/libexec/httpd-prepare && rpm-file-permissions \
+    && chmod -R a+rwx /var/lib/httpd \
+    && chmod -R a+rwx /var/log/httpd \
+    && cp /src/files/httpd-copy.sh /usr/share/container-scripts/httpd/pre-init/50-httpd-copy.sh
+#    && cp /src/files/acme-generate.sh /usr/share/container-scripts/httpd/pre-init/60-acme-generate.sh
 
 USER 1001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
-FROM registry.fedoraproject.org/fedora:29
+FROM registry.fedoraproject.org/f29/httpd:2.4
 
 ENV LANG=en_US.UTF-8
 # nicer output from the playbook run
 ENV ANSIBLE_STDOUT_CALLBACK=debug
-RUN ln -s /usr/bin/python3 /usr/bin/python \
-    && dnf install -y ansible
-
 # Ansible doesn't like /tmp
 COPY files/ /src/files/
+# We need to install packages. In httpd:2.4 container is user set to 1001
+USER 0
+
+# Commented. In httpd:2.4 image /usr/bin/python already exists
+#RUN ln -s /usr/bin/python3 /usr/bin/python && \
+RUN dnf install -y ansible
 
 # Install packages first and reuse the cache as much as possible
 RUN cd /src/ \
@@ -28,4 +31,6 @@ ENV USER=packit \
     LD_PRELOAD=libnss_wrapper.so \
     FLASK_APP=packit.service.web_hook
 
-CMD ["flask-3", "run", "-h", "0.0.0.0"]
+USER 1001
+
+CMD ["/usr/bin/run-httpd"]

--- a/files/httpd-copy.sh
+++ b/files/httpd-copy.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [[ -d "/httpd-conf" ]]; then
+    cp /httpd-conf/httpd-packit.conf /etc/httpd/conf.d/httpd-packit.conf
+fi

--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -25,6 +25,9 @@
       - fedpkg
       - python3-flask
       - nss_wrapper
-      - httpd
-      - mod_wsgi
+      - httpd-devel
+      - mod_md
+      - python3-devel
+      # till https://bodhi.fedoraproject.org/updates/FEDORA-2019-52487848d6 is not in official repos
+      enablerepo: testing      -
       state: present

--- a/files/packit.wsgi
+++ b/files/packit.wsgi
@@ -1,3 +1,5 @@
 # -*- coding: utf-8 -*-
+import sys
 
+sys.path.insert(0, "/usr/share/packit")
 from packit.service.web_hook import app as application

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -5,7 +5,8 @@
     user_name: packit
     home_path: /home/{{ user_name }}
     ansible_bender:
-      base_image: fedora:29
+      base_image: registry.fedoraproject.org/f29/httpd:2.4
+      #base_image: fedora:29
       target_image:
         name: docker.io/usercont/packit-service
         environment:
@@ -20,6 +21,35 @@
         volumes:
         - '{{ playbook_dir }}:/src:Z'
   tasks:
+  - name: Install all packages needed to hack on packit.
+    dnf:
+      name:
+      - python3-pip
+      - python3-setuptools
+      - git
+      - python3-setuptools_scm
+      - python3-setuptools_scm_git_archive
+      - python3-wheel  # for bdist_wheel
+      - python3-ipdb  # for easy debugging
+      - python3-fedmsg
+      - python3-pyyaml
+      - python3-rpm
+      - python3-GitPython
+      - python3-requests
+      - python3-pygithub
+      - python3-libpagure
+      - rpm-build
+      - rebase-helper
+      - fedpkg
+      - python3-flask
+      - nss_wrapper
+      - httpd
+      - mod_wsgi
+      - mod_md
+      # till https://bodhi.fedoraproject.org/updates/FEDORA-2019-52487848d6 is not in official repos
+      enablerepo: testing
+      state: present
+
   - user:
       name: '{{ user_name }}'
       create_home: yes
@@ -35,6 +65,17 @@
       dest: '{{ home_path }}/passwd'
       mode: 0777
 
+  # Workaround for https://bodhi.fedoraproject.org/updates/FEDORA-2019-52487848d6
+  - name: Remove /etc/httpd/state
+    file:
+      path: /etc/httpd/state
+      state: absent
+  # Workaround for https://bodhi.fedoraproject.org/updates/FEDORA-2019-52487848d6
+  - name: Create link to /etc/httpd/state
+    file:
+      src: /var/lib/httpd
+      dest: /etc/httpd/state
+      state: link
   - name: Create /usr/share/packit directory
     file:
       state: directory

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -21,35 +21,6 @@
         volumes:
         - '{{ playbook_dir }}:/src:Z'
   tasks:
-  - name: Install all packages needed to hack on packit.
-    dnf:
-      name:
-      - python3-pip
-      - python3-setuptools
-      - git
-      - python3-setuptools_scm
-      - python3-setuptools_scm_git_archive
-      - python3-wheel  # for bdist_wheel
-      - python3-ipdb  # for easy debugging
-      - python3-fedmsg
-      - python3-pyyaml
-      - python3-rpm
-      - python3-GitPython
-      - python3-requests
-      - python3-pygithub
-      - python3-libpagure
-      - rpm-build
-      - rebase-helper
-      - fedpkg
-      - python3-flask
-      - nss_wrapper
-      - httpd
-      - mod_wsgi
-      - mod_md
-      # till https://bodhi.fedoraproject.org/updates/FEDORA-2019-52487848d6 is not in official repos
-      enablerepo: testing
-      state: present
-
   - user:
       name: '{{ user_name }}'
       create_home: yes
@@ -101,6 +72,22 @@
     copy:
       src: files/ssh_config
       dest: /etc/ssh/ssh_config.d/01-packit.conf
+  - name: Install mod_wsgi from pip3
+    pip:
+      name:
+      - mod-wsgi
+      executable: pip3  # this requires to have sources mounted inside at /src
+  - name: Install mod-wsgi module with Python3 support
+    shell: mod_wsgi-express install-module > /etc/httpd/conf.modules.d/02-wsgi.conf
+  #- name: Clone acme.sh
+  #  git:
+  #    repo: 'https://github.com/Neilpang/acme.sh'
+  #    dest: /acme
+  #- name: Change permission on /acme
+  #  file:
+  #    state: directory
+  #    path: /acme
+  #    mode: 0777
   - name: stat /src
     stat:
       path: /src


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

Based on some articles, `packit.wsgi` has to be added into Python path.
See examples here:
- http://flask.pocoo.org/docs/1.0/deploying/mod_wsgi/#creating-a-wsgi-file
- https://www.bogotobogo.com/python/Flask/Python_Flask_HelloWorld_App_with_Apache_WSGI_Ubuntu14.php
- https://www.jakowicz.com/flask-apache-wsgi/


`.pre-commit-config.yaml` was modified because of this flake8 error:
~~~
Flake8...................................................................Failed
hookid: flake8

files/packit.wsgi:5:1: E402 module level import not at top of file

black....................................................................Failed
hookid: black
~~~