### PR TITLE
image build: cache packages installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PY_PACKAGE := packit
 PACKIT_IMAGE := docker.io/usercont/packit-service
 PACKIT_TESTS_IMAGE := packit-tests
 
-build: recipe.yaml
+build: recipe.yaml files/install-rpm-packages.yaml
 	docker build --rm -t $(PACKIT_IMAGE) .
 
 build-with-ab: recipe.yaml

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,6 @@ PACKIT_TESTS_IMAGE := packit-tests
 build: recipe.yaml files/install-rpm-packages.yaml
 	docker build --rm -t $(PACKIT_IMAGE) .
 
-build-with-ab: recipe.yaml
-	ansible-bender build -- ./recipe.yaml
-
-push-to-dockerd:
-	ansible-bender push docker-daemon:$(PACKIT_IMAGE):latest
-
 # we can't use rootless podman here b/c we can't mount ~/.ssh inside (0400)
 run: recipe.yaml
 	docker run -it --rm --net=host \
@@ -30,19 +24,6 @@ prepare-check:
 
 check:
 	tox
-
-check-pypi-packaging:
-	podman run --rm -ti -v $(CURDIR):/src:Z -w /src $(SOURCE_GIT_IMAGE) bash -c '\
-		set -x \
-		&& rm -f dist/* \
-		&& python3 ./setup.py sdist bdist_wheel \
-		&& pip3 install dist/*.tar.gz \
-		&& packit --help \
-		&& pip3 show $(PY_PACKAGE) \
-		&& twine check ./dist/* \
-		&& python3 -c "import packit; assert packit.__version__" \
-		&& pip3 show -f $(PY_PACKAGE) | ( grep test && exit 1 || :) \
-		'
 
 # build-tests: recipe-tests.yaml
 # 	ansible-bender build -- ./recipe-tests.yaml $(SOURCE_GIT_IMAGE) $(PACKIT_TESTS_IMAGE)

--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -1,0 +1,30 @@
+---
+- name: Install dependencies for packit.
+  hosts: all
+  tasks:
+  - name: Install all RPM packages needed to hack on packit.
+    dnf:
+      name:
+      - python3-pip
+      - python3-setuptools
+      - git
+      - python3-setuptools_scm
+      - python3-setuptools_scm_git_archive
+      - python3-wheel  # for bdist_wheel
+      - python3-ipdb  # for easy debugging
+      - python3-fedmsg
+      - python3-pyyaml
+      - python3-rpm
+      - python3-GitPython
+      - python3-requests
+      - python3-pygithub
+      - python3-libpagure
+      - python3-ogr
+      - rpm-build
+      - rebase-helper
+      - fedpkg
+      - python3-flask
+      - nss_wrapper
+      - httpd
+      - mod_wsgi
+      state: present

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -47,14 +47,6 @@
       group: apache
       mode: 0644
 
-  - name: Install latest twine for sake of check command
-    pip:
-      name:
-      - twine  # we need newest twine, b/c of the check command
-      - readme_renderer[md]
-      state: latest
-      executable: pip3
-  # TODO: we should do a git config instead
   - name: "Set up git: user.email"
     command: git config --global user.email "user-cont-team@redhat.com"
   - name: "Set up git: user.name"

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -4,7 +4,6 @@
   vars:
     user_name: packit
     home_path: /home/{{ user_name }}
-
     ansible_bender:
       base_image: fedora:29
       target_image:
@@ -20,34 +19,7 @@
       working_container:
         volumes:
         - '{{ playbook_dir }}:/src:Z'
-
   tasks:
-  - name: Install all packages needed to hack on packit.
-    dnf:
-      name:
-      - python3-pip
-      - python3-setuptools
-      - git
-      - python3-setuptools_scm
-      - python3-setuptools_scm_git_archive
-      - python3-wheel  # for bdist_wheel
-      - python3-ipdb  # for easy debugging
-      - python3-fedmsg
-      - python3-pyyaml
-      - python3-rpm
-      - python3-GitPython
-      - python3-requests
-      - python3-pygithub
-      - python3-libpagure
-      - rpm-build
-      - rebase-helper
-      - fedpkg
-      - python3-flask
-      - nss_wrapper
-      - httpd
-      - mod_wsgi
-      state: present
-
   - user:
       name: '{{ user_name }}'
       create_home: yes
@@ -106,12 +78,7 @@
     assert:
       that:
       - 'src_path.stat.isdir'
-  - name: Install ogr from master
-    pip:
-      name: git+http://github.com/packit-service/ogr.git
-      executable: pip3
-  # this requires to have sources mounted inside at /src
-  - name: Install packit from the current working directory
+  - name: Install packit from /src
     pip:
       name: /src
       executable: pip3


### PR DESCRIPTION
Fixes #274

~~Still not ideal since a change in recipe.yaml invalidates the cache, we should probably install packages in a dedicated playbook.~~