### PR TITLE
Fixes #255 refactor get_package_config_from_repo

### DIFF
--- a/packit/config.py
+++ b/packit/config.py
@@ -472,7 +472,7 @@ def get_local_package_config(
     raise PackitConfigException("No packit config found.")
 
 
-def get_packit_config_from_repo(
+def get_package_config_from_repo(
     sourcegit_project: GitProject, ref: str
 ) -> Optional[PackageConfig]:
     for config_file_name in CONFIG_FILE_NAMES:

--- a/packit/jobs.py
+++ b/packit/jobs.py
@@ -8,7 +8,7 @@ from ogr.abstract import GitProject, GitService
 
 from packit.api import PackitAPI
 from packit.config import JobConfig, JobTriggerType, JobType, PackageConfig, Config
-from packit.config import get_packit_config_from_repo
+from packit.config import get_package_config_from_repo
 from packit.distgit import DistGit
 from packit.exceptions import PackitException
 from packit.local_project import LocalProject
@@ -73,7 +73,7 @@ class SteveJobs:
             gh_proj = get_github_project(
                 self.config, repo=repo_name, namespace=repo_namespace
             )
-            package_config = get_packit_config_from_repo(gh_proj, release_ref)
+            package_config = get_package_config_from_repo(gh_proj, release_ref)
             https_url = event["repository"]["html_url"]
             package_config.upstream_project_url = https_url
             return JobTriggerType.release, package_config, gh_proj
@@ -113,7 +113,7 @@ class SteveJobs:
             gh_proj = get_github_project(
                 self.config, repo=base_repo_name, namespace=base_repo_namespace
             )
-            package_config = get_packit_config_from_repo(gh_proj, base_ref)
+            package_config = get_package_config_from_repo(gh_proj, base_ref)
             https_url = event["repository"]["html_url"]
             package_config.upstream_project_url = https_url
             return JobTriggerType.pull_request, package_config, gh_proj
@@ -145,7 +145,7 @@ class SteveJobs:
             dg_proj = self.pagure_service.get_project(
                 repo=repo_name, namespace=repo_namespace
             )
-            package_config = get_packit_config_from_repo(dg_proj, ref)
+            package_config = get_package_config_from_repo(dg_proj, ref)
             return JobTriggerType.commit, package_config, dg_proj
         return None
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -34,7 +34,7 @@ from packit.config import (
     JobTriggerType,
     SyncFilesConfig,
     SyncFilesItem,
-    get_packit_config_from_repo,
+    get_package_config_from_repo,
     Config,
     JobType,
     JobNotifyType,
@@ -475,10 +475,10 @@ def test_dist_git_package_url():
         '{"src": ".packit.yaml", "dest": ".packit2.yaml"}]}',
     ],
 )
-def test_get_packit_config_from_repo(content):
+def test_get_package_config_from_repo(content):
     flexmock(GitProject).should_receive("get_file_content").and_return(content)
     git_project = GitProject(repo="", service=GitService(), namespace="")
-    config = get_packit_config_from_repo(sourcegit_project=git_project, ref="")
+    config = get_package_config_from_repo(sourcegit_project=git_project, ref="")
     assert isinstance(config, PackageConfig)
     assert Path(config.specfile_path).name == "packit.spec"
     assert config.synced_files == SyncFilesConfig(


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

I have renamed `get_packit_config_from_repo` into `get_package_config_from_repo`.

-----

Fixes #255 