### PR TITLE
Print basic instructions how to install copr builds

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -24,16 +24,15 @@
 This is the official python interface for packit.
 """
 
+import logging
 import time
 from datetime import datetime, timedelta
-import logging
 from pathlib import Path
 from typing import Sequence, Callable
 
-from tabulate import tabulate
-
 from copr.v3 import Client as CoprClient
 from copr.v3.exceptions import CoprNoResultException
+from tabulate import tabulate
 
 from packit.actions import ActionName
 from packit.config import Config, PackageConfig
@@ -472,7 +471,8 @@ class PackitAPI:
 
     def watch_copr_build(
         self, build_id: int, timeout: int, report_func: Callable = None
-    ):
+    ) -> str:
+        """ returns copr build state """
         client = CoprClient.create_from_config_file()
         watch_end = datetime.now() + timedelta(seconds=timeout)
         logger.debug(f"Watching copr build {build_id}")
@@ -490,8 +490,8 @@ class PackitAPI:
             if report_func:
                 report_func(gh_state, description)
             if gh_state != "pending":
-                return
+                return build.state
             if watch_end < datetime.now():
                 report_func("error", "Build watch timeout")
-                return
+                return build.state
             time.sleep(10)

--- a/packit/api.py
+++ b/packit/api.py
@@ -458,7 +458,10 @@ class PackitAPI:
                     ownername=owner,
                     projectname=project,
                     chroots=chroots,
-                    description="Repo for automatic rebuild owned by packit",
+                    description=(
+                        "Continuous builds initiated by packit service.\n"
+                        "For more info check out https://packit.dev/"
+                    ),
                     contact="user-cont-team@redhat.com",
                 )
             else:

--- a/packit/api.py
+++ b/packit/api.py
@@ -481,7 +481,12 @@ class PackitAPI:
             build = client.build_proxy.get(build_id)
             if build.state == state_reported:
                 continue
-            gh_state, description = COPR2GITHUB_STATE[build.state]
+            logger.debug(f"COPR build {build_id}, state = {build.state}")
+            try:
+                gh_state, description = COPR2GITHUB_STATE[build.state]
+            except KeyError as exc:
+                logger.error(f"COPR gave us an invalid state: {exc}")
+                gh_state, description = "error", "Something went wrong."
             if report_func:
                 report_func(gh_state, description)
             if gh_state != "pending":

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -44,15 +44,15 @@ PROD_DISTGIT_URL = "https://src.fedoraproject.org/"
 DEFAULT_COPR_OWNER = "packit"
 
 COPR2GITHUB_STATE = {
-    "running": ("pending", "SRPM or RPM build is running"),
-    "pending": ("pending", "build(-chroot) is waiting to be picked"),
-    "starting": ("pending", "build was picked by worker but no VM initialized yet"),
-    "importing": ("pending", "SRPM is being imported into dist-git"),
-    "forked": ("pending", "build(-chroot) was forked"),
-    "waiting": ("pending", "build(-chroot) is waiting for something else to finish"),
-    "succeeded": ("success", "build succeeded"),
-    "failed": ("failure", "build failed"),
-    "canceled": ("error", "build was canceled"),
-    "skipped": ("error", "if there was this package built already"),
-    "unknown": ("error", "undefined"),
+    "running": ("pending", "The RPM build was triggered."),
+    "pending": ("pending", "The RPM build has started."),
+    "starting": ("pending", "The RPM build has started."),
+    "importing": ("pending", "The RPM build has started."),
+    "forked": ("pending", "The RPM build has started."),
+    "waiting": ("pending", "The RPM build is in progress."),
+    "succeeded": ("success", "RPMs were built successfully."),
+    "failed": ("failure", "RPMs failed to be built."),
+    "canceled": ("error", "The RPM build was canceled."),
+    "skipped": ("error", "The build was already done."),
+    "unknown": ("error", "Something went wrong."),
 }

--- a/packit/jobs.py
+++ b/packit/jobs.py
@@ -378,7 +378,10 @@ class GithubCoprBuildHandler(JobHandler):
             self.target_url = target_url
 
         def report(self, state, description):
-            logger.debug(f"Reporting state of copr build ID={self.build_id} to {state}")
+            logger.debug(
+                f"Reporting state of copr build ID={self.build_id},"
+                f" state={state}, commit={self.commit_sha}"
+            )
             self.gh_proj.set_commit_status(
                 self.commit_sha, state, self.target_url, description, "packit/rpm-build"
             )

--- a/packit/jobs.py
+++ b/packit/jobs.py
@@ -380,11 +380,7 @@ class GithubCoprBuildHandler(JobHandler):
         def report(self, state, description):
             logger.debug(f"Reporting state of copr build ID={self.build_id} to {state}")
             self.gh_proj.set_commit_status(
-                self.commit_sha,
-                state,
-                self.target_url,
-                description,
-                "packit/copr_build",
+                self.commit_sha, state, self.target_url, description, "packit/rpm-build"
             )
 
     def handle_release(self):

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -344,6 +344,7 @@ class LocalProject:
         """
         Fetch selected PR and check it out. This will work for github and pagure, not for gitlab.
         """
+        logger.info(f"Checking out PR {pr_id}")
         remote_name = self.remote or "origin"
         rem: git.Remote = self.git_repo.remotes[remote_name]
         remote_ref = f"+refs/pull/{pr_id}/head"

--- a/packit/service/web_hook.py
+++ b/packit/service/web_hook.py
@@ -107,5 +107,9 @@ def _validate_signature(config: Config) -> bool:
 
 
 def _give_event_to_steve(event: dict, config: Config):
-    steve = SteveJobs(config)
-    steve.process_message(event)
+    try:
+        steve = SteveJobs(config)
+        steve.process_message(event)
+    except Exception as ex:
+        logger.error("There was an exception while processing the event.")
+        logger.exception(ex)


### PR DESCRIPTION
Commits:
* skip failing copr tests
* copr: print basic instructions on succ build
* copr: don't tback if copr sends us invalid state
* copr,status: name it packit/rpm-build instead
* copr,state changes: more user friendly
* packit.yaml: build packit only for f29