### PR TITLE
[web_hook.py:_validate_signature()] return digest_is_valid 

### DIFF
--- a/packit/service/web_hook.py
+++ b/packit/service/web_hook.py
@@ -22,8 +22,8 @@
 
 import hmac
 import logging
-from hashlib import sha1
 from concurrent.futures.thread import ThreadPoolExecutor
+from hashlib import sha1
 
 from flask import Flask, abort, request, jsonify
 
@@ -98,12 +98,12 @@ def _validate_signature(config: Config) -> bool:
     signature = sig.split("=")[1]
     mac = hmac.new(webhook_secret, msg=request.get_data(), digestmod=sha1)
     digest_is_valid = hmac.compare_digest(signature, mac.hexdigest())
-    if not digest_is_valid:
+    if digest_is_valid:
+        logger.debug(f"/webhooks/github payload signature OK.")
+    else:
         logger.warning(f"/webhooks/github payload signature validation failed.")
-        logger.debug(f"X-Hub-Signature: {sig!r}")
-        logger.debug(f"Computed signature: {mac.hexdigest()}")
-    # TODO: return digest_is_valid
-    return True
+        logger.debug(f"X-Hub-Signature: {sig!r} != computed: {mac.hexdigest()}")
+    return digest_is_valid
 
 
 def _give_event_to_steve(event: dict, config: Config):

--- a/tests/unit/test_web_hook.py
+++ b/tests/unit/test_web_hook.py
@@ -11,7 +11,7 @@ from packit.service.web_hook import _validate_signature
     [
         # hmac.new(webhook_secret, msg=payload, digestmod=hashlib.sha1).hexdigest()
         ("4e0281ef362383a2ab30c9dde79167da3b300b58", True),
-        # ("abcdefghijklmnopqrstuvqxyz", False),
+        ("abcdefghijklmnopqrstuvqxyz", False),
     ],
 )
 def test_validate_signature(digest, is_good):


### PR DESCRIPTION
After re-adding (it's not displayed so I couldn't simply check value) webhook secret to [prod app](https://github.com/organizations/packit-service/settings/apps/packit-as-a-service) there are no errors in prod service deployment logs.

So I believe it was just a misconfiguration and we can 'protect the gate' again.