### PR TITLE
Use asyncio for asynchronous task in status

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -413,7 +413,8 @@ class PackitAPI:
         srpm_path = self.up.create_srpm(srpm_path=output_file, srpm_dir=srpm_dir)
         return srpm_path
 
-    async def status_get_downstream_prs(self, status) -> List[Tuple[int, str, str]]:
+    @staticmethod
+    async def status_get_downstream_prs(status) -> List[Tuple[int, str, str]]:
         try:
             return status.get_downstream_prs()
         except Exception as exc:
@@ -421,16 +422,20 @@ class PackitAPI:
             logger.error(f"Failed when getting downstream PRs: {exc}")
             return []
 
-    async def status_get_dg_versions(self, status) -> Dict:
+    @staticmethod
+    async def status_get_dg_versions(status) -> Dict:
         return status.get_dg_versions()
 
-    async def status_get_up_releases(self, status) -> List:
+    @staticmethod
+    async def status_get_up_releases(status) -> List:
         return status.get_up_releases()
 
-    async def status_get_builds(self, status) -> Dict:
+    @staticmethod
+    async def status_get_builds(status) -> Dict:
         return status.get_builds()
 
-    async def status_get_updates(self, status) -> List:
+    @staticmethod
+    async def status_get_updates(status) -> List:
         return status.get_updates()
 
     def status(self):
@@ -448,35 +453,39 @@ class PackitAPI:
         (ds_prs, dg_versions, up_releases, builds, updates) = res
 
         if ds_prs:
-            logger.info("Downstream PRs:")
+            logger.info("\nDownstream PRs:")
             logger.info(tabulate(ds_prs, headers=["ID", "Title", "URL"]))
         else:
-            logger.info("Downstream PRs: No open PRs.")
+            logger.info("\nNo downstream PRs found.")
 
         if dg_versions:
-            logger.info("Dist-git versions:")
+            logger.info("\nDist-git versions:")
             for branch, dg_version in dg_versions.items():
                 logger.info(f"{branch}: {dg_version}")
+        else:
+            logger.info("\nNo Dist-git versions found")
 
         if up_releases:
-            logger.info("\nGitHub upstream releases:")
+            logger.info("\nUpstream releases:")
             upstream_releases_str = "\n".join(
                 f"{release.tag_name}" for release in up_releases
             )
             logger.info(upstream_releases_str)
         else:
-            logger.info("\nGitHub upstream releases: No releases found.")
+            logger.info("\nNo upstream releases found.")
 
         if updates:
-            logger.info("\nLatest bodhi updates:")
+            logger.info("\nLatest Bodhi updates:")
             logger.info(tabulate(updates, headers=["Update", "Karma", "status"]))
+        else:
+            logger.info("\nNo Bodhi updates found")
 
         if builds:
-            logger.info("\nLatest builds:")
+            logger.info("\nLatest Koji builds:")
             for branch, branch_builds in builds.items():
                 logger.info(f"{branch}: {branch_builds}")
         else:
-            logger.info("There are no builds.")
+            logger.info("No Koji builds found.")
 
     def run_copr_build(self, owner, project, chroots):
         # get info

--- a/packit/cli/status.py
+++ b/packit/cli/status.py
@@ -55,5 +55,4 @@ def status(config, path_or_url):
     """
 
     api = get_packit_api(config=config, local_project=path_or_url)
-
     api.status()

--- a/packit/status.py
+++ b/packit/status.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 import logging
+
 from typing import List, Tuple, Dict
 
 from ogr.abstract import Release

--- a/packit/status.py
+++ b/packit/status.py
@@ -60,6 +60,7 @@ class Status:
         """
         table: List[Tuple[int, str, str]] = []
         pr_list = self.dg.local_project.git_project.get_pr_list()
+        logger.debug("Downstream PRs fetched.")
         if len(pr_list) > 0:
             # take last `number_of_prs` PRs
             pr_list = (
@@ -75,6 +76,7 @@ class Status:
         """
         dg_versions = {}
         branches = self.dg.local_project.git_project.get_branches()
+        logger.debug("Dist-git branches fetched.")
         for branch in branches:
             try:
                 self.dg.create_branch(
@@ -101,15 +103,13 @@ class Status:
         if not self.up.local_project.git_project:
             logger.info("We couldn't track any upstream releases.")
             return []
+
         latest_releases: List[Release] = []
         try:
             latest_releases = self.up.local_project.git_project.get_releases()
-            logger.debug("GitHub upstream releases fetched.")
+            logger.debug("Upstream releases fetched.")
         except PackitException as e:
             logger.debug("Failed to fetch upstream releases: %s", e)
-
-        if not latest_releases:
-            logger.debug("GitHub upstream releases: No releases found.")
 
         return latest_releases[:number_of_releases]
 
@@ -124,10 +124,11 @@ class Status:
         # { koji-target: "latest-build-nvr"}
         builds_d = b.latest_builds(self.dg.package_name)
         branches = self.dg.local_project.git_project.get_branches()
+        logger.debug("Latest koji builds fetched.")
         builds: Dict = {}
         for branch in branches:
             # there is no master tag in koji
-            if branch == ("master"):
+            if branch == "master":
                 continue
             koji_tag = f"{branch}-updates-candidate"
             try:
@@ -147,6 +148,7 @@ class Status:
 
         b = BodhiClient()
         results = b.query(packages=self.dg.package_name)["updates"]
+        logger.debug("Bodhi updates fetched.")
         results = results[:number_of_updates]
 
         return [


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

Using asyncio API for getting statuses asynchronously.
After reading API, I have selected https://docs.python.org/3/library/asyncio-task.html#running-tasks-concurrently

If you switch t1-t5 to another order, then you should see similar output.