### PR TITLE
Adapt to changes in rebasehelper plugins

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -29,7 +29,11 @@ from typing import Optional, List, Tuple
 import git
 from packaging import version
 from rebasehelper.exceptions import RebaseHelperError
-from rebasehelper.versioneer import versioneers_runner
+
+try:
+    from rebasehelper.plugins.plugin_manager import plugin_manager
+except ImportError:
+    from rebasehelper.versioneer import versioneers_runner
 
 from packit.actions import ActionName
 from packit.base_git import PackitRepositoryBase
@@ -301,7 +305,12 @@ class Upstream(PackitRepositoryBase):
 
         :return: the version string (e.g. "1.0.0")
         """
-        version = versioneers_runner.run(
+        try:
+            get_version = plugin_manager.versioneers.run
+        except NameError:
+            get_version = versioneers_runner.run
+
+        version = get_version(
             versioneer=None,
             package_name=self.package_config.downstream_package_name,
             category=None,

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -30,7 +30,11 @@ from pathlib import Path
 
 import pytest
 from flexmock import flexmock
-from rebasehelper.versioneer import versioneers_runner
+
+try:
+    from rebasehelper.plugins.plugin_manager import plugin_manager
+except ImportError:
+    from rebasehelper.versioneer import versioneers_runner
 
 from packit.config import Config
 from packit.exceptions import PackitException
@@ -59,7 +63,10 @@ def test_get_current_version(upstream_instance):
 )
 def test_get_version(upstream_instance, m_v, exp):
     u, ups = upstream_instance
-    flexmock(versioneers_runner, run=lambda **kw: m_v)
+    try:
+        flexmock(plugin_manager.versioneers, run=lambda **kw: m_v)
+    except NameError:
+        flexmock(versioneers_runner, run=lambda **kw: m_v)
 
     assert ups.get_version() == exp
 


### PR DESCRIPTION
Plugins have been refactored, individual runners removed and replaced with plugin manager. The change will be part of 0.17.0 release.