### PR TITLE
set up PersistentObjectStorage in get_github_service

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,21 @@ make build-tests && make test-in-container
 
 As a CI we use [CentOS CI](https://ci.centos.org/job/packit-pr/) with a configuration in [Jenkinsfile](Jenkinsfile).
 
+
+#### Storing HTTP communication offline
+
+OGR enables you to store complete HTTP requests offline. We can then use those
+cached HTTP communication during testing.
+
+In order to use this feature, you have to set `github_requests_log_path` on
+`Config`. You can then use `get_github_service` from `ogr_services` to get
+GithubService which has everything set up:
+
+1. If `github_token` is set, all the HTTP requests will be stored in the file
+2. If the token is not set, offline http requests will be used instead of
+   talking to live GitHub API.
+
+
 ### Makefile
 
 #### Requirements

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ Options:
  conu              |                           | [.packit.yaml](https://github.com/user-cont/conu/blob/master/.packit.yaml)
  sen               | @TomasTomecek             | [.packit.yaml](https://github.com/TomasTomecek/sen/blob/master/.packit.yaml)
  ogr               | @lachmanfrantisek         | [.packit.yaml](https://github.com/packit-service/ogr/blob/master/.packit.yaml)
- rear               | @gdha                    | [PR2145](https://github.com/rear/rear/pull/2145)
- 
+ rear              | @gdha                     | [PR2145](https://github.com/rear/rear/pull/2145)
+
 ## Who is interested
 
 * Identity team (@pvoborni)

--- a/packit/config.py
+++ b/packit/config.py
@@ -86,6 +86,10 @@ class Config(BaseConfig):
         self._pagure_fork_token: str = ""
         self.dry_run: bool = False
 
+        # path to a file where OGR should store HTTP requests
+        # this is used for packit testing: don't expose this to users
+        self.github_requests_log_path: str = ""
+
     @classmethod
     def get_user_config(cls) -> "Config":
         xdg_config_home = os.getenv("XDG_CONFIG_HOME")

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -25,6 +25,7 @@ from typing import Optional, Sequence, List
 
 import git
 import requests
+from ogr.services.pagure import PagureService
 
 from packit.base_git import PackitRepositoryBase
 from packit.config import (
@@ -36,7 +37,6 @@ from packit.config import (
 from packit.exceptions import PackitException, PackitConfigException
 from packit.fedpkg import FedPKG
 from packit.local_project import LocalProject
-from packit.ogr_services import PagureService
 
 logger = logging.getLogger(__name__)
 

--- a/packit/jobs.py
+++ b/packit/jobs.py
@@ -5,6 +5,7 @@ import logging
 from typing import List, Optional, Tuple, Dict, Type
 
 from ogr.abstract import GitProject, GitService
+from ogr.services.pagure import PagureService
 
 from packit.api import PackitAPI
 from packit.config import JobConfig, JobTriggerType, JobType, PackageConfig, Config
@@ -12,7 +13,7 @@ from packit.config import get_package_config_from_repo
 from packit.distgit import DistGit
 from packit.exceptions import PackitException, FailedCreateSRPM
 from packit.local_project import LocalProject
-from packit.ogr_services import PagureService, get_github_project
+from packit.ogr_services import get_github_project
 from packit.utils import nested_get, get_namespace_and_repo_name
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
so that we can utilize it easily in tests

also

```
drop the read_only compat workaround

we have ogr already available in fedora
```