### PR TITLE
Move run_command functions into CommandRunner class

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -84,7 +84,7 @@ class PackitAPI:
         # do not add anything between distgit clone and saving gpg keys!
         self.up.allowed_gpg_keys = self.dg.get_allowed_gpg_keys_from_downstream_config()
 
-        self.up.run_action(action=ActionName.pre_sync)
+        self.up.command_runner.run_action(action=ActionName.pre_sync)
 
         self.up.checkout_pr(pr_id=pr_id)
         self.dg.check_last_commit()
@@ -103,7 +103,7 @@ class PackitAPI:
         self.dg.create_branch(local_pr_branch)
         self.dg.checkout_branch(local_pr_branch)
 
-        if self.up.with_action(action=ActionName.create_patches):
+        if self.up.command_runner.with_action(action=ActionName.create_patches):
             patches = self.up.create_patches(
                 upstream=upstream_version, destination=self.dg.specfile_dir
             )
@@ -149,7 +149,7 @@ class PackitAPI:
 
         upstream_ref = upstream_ref or self.package_config.upstream_ref
 
-        self.up.run_action(action=ActionName.post_upstream_clone)
+        self.up.command_runner.run_action(action=ActionName.post_upstream_clone)
 
         full_version = version or self.up.get_version()
         if not full_version:
@@ -168,7 +168,7 @@ class PackitAPI:
 
             self.dg.check_last_commit()
 
-            self.up.run_action(action=ActionName.pre_sync)
+            self.up.command_runner.run_action(action=ActionName.pre_sync)
 
             local_pr_branch = f"{full_version}-{dist_git_branch}-update"
             # fetch and reset --hard upstream/$branch?
@@ -191,14 +191,16 @@ class PackitAPI:
                 f"Upstream commit: {self.up.local_project.git_repo.head.commit}\n"
             )
 
-            if self.up.with_action(action=ActionName.prepare_files):
+            if self.up.command_runner.with_action(action=ActionName.prepare_files):
                 raw_sync_files = self.package_config.synced_files.get_raw_files_to_sync(
                     Path(self.up.local_project.working_dir),
                     Path(self.dg.local_project.working_dir),
                 )
                 sync_files(raw_sync_files)
                 if upstream_ref:
-                    if self.up.with_action(action=ActionName.create_patches):
+                    if self.up.command_runner.with_action(
+                        action=ActionName.create_patches
+                    ):
                         patches = self.up.create_patches(
                             upstream=upstream_ref, destination=self.dg.specfile_dir
                         )
@@ -208,7 +210,7 @@ class PackitAPI:
                     add_new_sources=True, force_new_sources=force_new_sources
                 )
 
-            if self.up.has_action(action=ActionName.prepare_files):
+            if self.up.command_runner.has_action(action=ActionName.prepare_files):
                 raw_sync_files = self.package_config.synced_files.get_raw_files_to_sync(
                     Path(self.up.local_project.working_dir),
                     Path(self.dg.local_project.working_dir),
@@ -386,7 +388,7 @@ class PackitAPI:
         :param srpm_dir: path to the directory where the srpm is meant to be placed
         :return: a path to the srpm
         """
-        self.up.run_action(action=ActionName.post_upstream_clone)
+        self.up.command_runner.run_action(action=ActionName.post_upstream_clone)
 
         version = upstream_ref or self.up.get_current_version()
         spec_version = self.up.get_specfile_version()
@@ -402,7 +404,7 @@ class PackitAPI:
                 self.up.create_archive(version=upstream_ref)
 
         if upstream_ref:
-            if self.up.with_action(action=ActionName.create_patches):
+            if self.up.command_runner.with_action(action=ActionName.create_patches):
                 patches = self.up.create_patches(
                     upstream=upstream_ref, destination=self.up.specfile_dir
                 )

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -22,18 +22,16 @@
 import inspect
 import logging
 from pathlib import Path
-from typing import Optional, Callable, List, Tuple
+from typing import Optional, List, Tuple
 
 import git
 from rebasehelper.specfile import SpecFile
 
-from packit import utils
-from packit.actions import ActionName
 from packit.config import Config, PackageConfig
 from packit.exceptions import PackitException
 from packit.local_project import LocalProject
 from packit.security import CommitVerifier
-from packit.utils import run_command, cwd
+from packit.utils import cwd
 
 logger = logging.getLogger(__name__)
 
@@ -163,83 +161,6 @@ class PackitRepositoryBase:
         #       distribute it to the container, prepare git config and then we can start signing
         # TODO: make -s configurable
         self.local_project.git_repo.git.commit(*commit_args)
-
-    def run_action(self, action: ActionName, method: Callable = None, *args, **kwargs):
-        """
-        Run the method in the self._with_action block.
-
-        Usage:
-
-        >   self._run_action(
-        >        action_name="sync", method=dg.sync_files, upstream_project=up.local_project
-        >   )
-        >   # If user provided custom command for the `sync`, it will be used.
-        >   # Otherwise, the method `dg.sync_files` will be used
-        >   # with parameter `upstream_project=up.local_project`
-        >
-        >   self._run_action(action_name="pre-sync")
-        >   # This will be used as an optional hook
-
-        :param action: ActionName enum (Name of the action that can be overwritten
-                                                in the package_config.actions)
-        :param method: method to run if the action was not defined by user
-                    (if not specified, the action can be used for custom hooks)
-        :param args: args for the method
-        :param kwargs: kwargs for the method
-        """
-        if not method:
-            logger.debug(f"Running {action} hook.")
-        if self.with_action(action=action):
-            if method:
-                method(*args, **kwargs)
-
-    def has_action(self, action: ActionName) -> bool:
-        """
-        Is the action defined in the config?
-        """
-        return action in self.package_config.actions
-
-    def with_action(self, action: ActionName) -> bool:
-        """
-        If the action is defined in the self.package_config.actions,
-        we run it and return False (so we can skip the if block)
-
-        If the action is not defined, return True.
-
-        Usage:
-
-        >   if self._with_action(action_name="patch"):
-        >       # Run default implementation
-        >
-        >   # Custom command was run if defined in the config
-
-        Context manager is currently not possible without ugly hacks:
-        https://stackoverflow.com/questions/12594148/skipping-execution-of-with-block
-        https://www.python.org/dev/peps/pep-0377/ (rejected)
-
-        :param action: ActionName enum (Name of the action that can be overwritten
-                                                in the package_config.actions)
-        :return: True, if the action is not overwritten, False when custom command was run
-        """
-        logger.debug(f"Running {action}.")
-        if action in self.package_config.actions:
-            command = self.package_config.actions[action]
-            logger.info(f"Using user-defined script for {action}: {command}")
-            utils.run_command(cmd=command, cwd=self.local_project.working_dir)
-            return False
-        logger.debug(f"Running default implementation for {action}.")
-        return True
-
-    def get_output_from_action(self, action: ActionName):
-        """
-        Run action if specified in the self.actions and return output
-        else return None
-        """
-        if action in self.package_config.actions:
-            command = self.package_config.actions[action]
-            logger.info(f"Using user-defined script for {action}: {command}")
-            return run_command(cmd=command, output=True)
-        return None
 
     def add_patches_to_specfile(self, patch_list: List[Tuple[str, str]]) -> None:
         """

--- a/packit/command_runner.py
+++ b/packit/command_runner.py
@@ -1,0 +1,99 @@
+import logging
+from typing import Callable
+
+from packit import utils
+from packit.actions import ActionName
+from packit.utils import run_command
+from packit.config import Config, PackageConfig
+from packit.local_project import LocalProject
+
+logger = logging.getLogger(__name__)
+
+
+class CommandRunner:
+    # mypy complains when this is a property
+    local_project: LocalProject
+
+    def __init__(
+        self, config: Config, package_config: PackageConfig, local_project: LocalProject
+    ):
+        self.config = config
+        self.package_config = package_config
+        self.local_project = local_project
+
+    def run_action(self, action: ActionName, method: Callable = None, *args, **kwargs):
+        """
+        Run the method in the self._with_action block.
+
+        Usage:
+
+        >   self._run_action(
+        >        action_name="sync", method=dg.sync_files, upstream_project=up.local_project
+        >   )
+        >   # If user provided custom command for the `sync`, it will be used.
+        >   # Otherwise, the method `dg.sync_files` will be used
+        >   # with parameter `upstream_project=up.local_project`
+        >
+        >   self._run_action(action_name="pre-sync")
+        >   # This will be used as an optional hook
+
+        :param action: ActionName enum (Name of the action that can be overwritten
+                                                in the package_config.actions)
+        :param method: method to run if the action was not defined by user
+                    (if not specified, the action can be used for custom hooks)
+        :param args: args for the method
+        :param kwargs: kwargs for the method
+        """
+        if not method:
+            logger.debug(f"Running {action} hook.")
+        if self.with_action(action=action):
+            if method:
+                method(*args, **kwargs)
+
+    def has_action(self, action: ActionName) -> bool:
+        """
+        Is the action defined in the config?
+        """
+        return action in self.package_config.actions
+
+    def with_action(self, action: ActionName) -> bool:
+        """
+        If the action is defined in the self.package_config.actions,
+        we run it and return False (so we can skip the if block)
+
+        If the action is not defined, return True.
+
+        Usage:
+
+        >   if self._with_action(action_name="patch"):
+        >       # Run default implementation
+        >
+        >   # Custom command was run if defined in the config
+
+        Context manager is currently not possible without ugly hacks:
+        https://stackoverflow.com/questions/12594148/skipping-execution-of-with-block
+        https://www.python.org/dev/peps/pep-0377/ (rejected)
+
+        :param action: ActionName enum (Name of the action that can be overwritten
+                                                in the package_config.actions)
+        :return: True, if the action is not overwritten, False when custom command was run
+        """
+        logger.debug(f"Running {action}.")
+        if action in self.package_config.actions:
+            command = self.package_config.actions[action]
+            logger.info(f"Using user-defined script for {action}: {command}")
+            utils.run_command(cmd=command, cwd=self.local_project.working_dir)
+            return False
+        logger.debug(f"Running default implementation for {action}.")
+        return True
+
+    def get_output_from_action(self, action: ActionName):
+        """
+        Run action if specified in the self.actions and return output
+        else return None
+        """
+        if action in self.package_config.actions:
+            command = self.package_config.actions[action]
+            logger.info(f"Using user-defined script for {action}: {command}")
+            return run_command(cmd=command, output=True)
+        return None

--- a/tests/integration/test_base_git.py
+++ b/tests/integration/test_base_git.py
@@ -1,19 +1,18 @@
 from flexmock import flexmock
 
 from packit.actions import ActionName
-from packit.base_git import PackitRepositoryBase
 from packit.config import PackageConfig
+from packit.command_runner import CommandRunner
 
 
 def test_get_output_from_action_defined():
     echo_cmd = "echo 'hello world'"
 
-    packit_repository_base = PackitRepositoryBase(
+    command_runner = CommandRunner(
         config=flexmock(),
         package_config=flexmock(PackageConfig(actions={ActionName.pre_sync: echo_cmd})),
+        local_project=flexmock(working_dir="."),
     )
 
-    packit_repository_base.local_project = flexmock(working_dir=".")
-
-    result = packit_repository_base.get_output_from_action(ActionName.pre_sync)
+    result = command_runner.get_output_from_action(ActionName.pre_sync)
     assert result == "hello world\n"

--- a/tests/unit/test_base_git.py
+++ b/tests/unit/test_base_git.py
@@ -40,6 +40,7 @@ def command_runner():
                 }
             )
         ),
+        local_project=flexmock(working_dir="."),
     )
 
 


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

This pull request only moves run_command and the other functions into an alone class called CommandRunner.
This is the first step before using OpenShift `oc exec` in CommandRunner.
