### PR TITLE
work-around a service bug

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -8,8 +8,8 @@ synced_files:
 # packit was already taken on PyPI
 upstream_project_name: packitos
 downstream_package_name: packit
-current_version_command: ["python3", "setup.py", "--version"]
-create_tarball_command: ["python3", "setup.py", "sdist", "--dist-dir", "."]
+current_version_command: ["bash", "-c", "git checkout -q fedora-tests/ && python3 setup.py --version"]
+create_tarball_command: ["bash", "-c", "git checkout -q fedora-tests/ && python3 setup.py sdist --dist-dir ."]
 jobs:
 - job: propose_downstream
   trigger: release

--- a/packit/api.py
+++ b/packit/api.py
@@ -405,7 +405,7 @@ class PackitAPI:
         else:
             with self.up.local_project.git_checkout_block(ref=upstream_ref):
                 # upstream repo: create the archive
-                self.up.create_archive(version=upstream_ref)
+                self.up.create_archive(version=version)
 
         if upstream_ref:
             if self.up.with_action(action=ActionName.create_patches):


### PR DESCRIPTION
\+ srpm & upstream: use version since upstream_ref is empty