### PR TITLE
support copr builds in CLI

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -541,9 +541,11 @@ class PackitAPI:
         self, project: str, chroots: List[str], owner: str = None
     ) -> Tuple[int, str]:
         """
+        Submit a build to copr build system using an SRPM using the current checkout.
 
-        :param project:
-        :param chroots:
+        :param project: name of the copr project to build
+                        inside (defaults to something long and ugly)
+        :param chroots: a list of COPR chroots (targets) e.g. fedora-rawhide-x86_64
         :param owner: defaults to username from copr config file
         :return: id of the created build and url to its repo
         """

--- a/packit/cli/copr_build.py
+++ b/packit/cli/copr_build.py
@@ -1,0 +1,66 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from os import getcwd
+
+import click
+
+from packit.cli.types import LocalProjectParameter
+from packit.cli.utils import cover_packit_exception, get_packit_api
+from packit.config import pass_config, get_context_settings
+
+
+@click.command("copr-build", context_settings=get_context_settings())
+@click.option("--nowait", is_flag=True, default=False, help="Don't wait for build")
+@click.option(
+    "--owner",
+    help="Copr user, owner of the project. (defaults to username from copr config)",
+)
+@click.option(
+    "--project",
+    help="Project name to build in. Will be created if does not exist. "
+    "(defaults to 'packit-cli-{repo_name}-{branch/commit}')",
+)
+@click.option(
+    "--targets",
+    help="Comma separated list of chroots to build in. (defaults to 'fedora-rawhide-x86_64')",
+    default="fedora-rawhide-x86_64",
+)
+@click.argument("path_or_url", type=LocalProjectParameter(), default=getcwd())
+@pass_config
+@cover_packit_exception
+def copr_build(config, nowait, owner, project, targets, path_or_url):
+    """
+    Build selected upstream project in COPR.
+
+    PATH_OR_URL argument is a local path or a URL to the upstream git repository,
+    it defaults to the current working directory.
+    """
+    api = get_packit_api(config=config, local_project=path_or_url)
+    default_project_name = f"packit-cli-{path_or_url.repo_name}-{path_or_url.ref}"
+    build_id, repo_url = api.run_copr_build(
+        project=project or default_project_name, chroots=targets.split(","), owner=owner
+    )
+    click.echo(f"Build id: {build_id}, repo url: {repo_url}")
+    if not nowait:
+        api.watch_copr_build(build_id=build_id, timeout=60 * 60 * 2)

--- a/packit/cli/packit_base.py
+++ b/packit/cli/packit_base.py
@@ -25,6 +25,7 @@ import logging
 import click
 from pkg_resources import get_distribution
 
+from packit.cli.copr_build import copr_build
 from packit.cli.build import build
 from packit.cli.create_update import create_update
 from packit.cli.srpm import srpm
@@ -75,6 +76,7 @@ packit_base.add_command(version)
 packit_base.add_command(update)
 packit_base.add_command(sync_from_downstream)
 packit_base.add_command(build)
+packit_base.add_command(copr_build)
 packit_base.add_command(create_update)
 packit_base.add_command(srpm)
 packit_base.add_command(status)

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -43,8 +43,6 @@ DEFAULT_BODHI_NOTE = "New upstream release: {version}"
 
 PROD_DISTGIT_URL = "https://src.fedoraproject.org/"
 
-DEFAULT_COPR_OWNER = "packit"
-
 COPR2GITHUB_STATE = {
     "running": ("pending", "The RPM build was triggered."),
     "pending": ("pending", "The RPM build has started."),


### PR DESCRIPTION
Fixes #366 

If you just run `packit -d copr-build` from my branch you might be wondering why the COPR project name is [packit-cli-packit-cli-copr-build](https://copr.fedorainfracloud.org/coprs/jpopelka/packit-cli-packit-cli-copr-build/builds/)  :-)
It's OK, the default (if not specified with `--project`) project name is `packit-cli-{repo_name}-{branch/commit}`, where in this case `repo_name` is `packit` and `branch` is `cli-copr-build`.