### PR TITLE
Add support for other tarball formats

### DIFF
--- a/packit/constants.py
+++ b/packit/constants.py
@@ -31,6 +31,13 @@ CONFIG_FILE_NAMES = [
     "packit.json",
 ]
 
+COMMON_ARCHIVE_EXTENSIONS = [
+    ".tar.gz",
+    ".tar.bz2",
+    ".tar.xz",
+    ".zip",
+]
+
 # fedmsg topics
 URM_NEW_RELEASE_TOPIC = "org.release-monitoring.prod.anitya.project.version.update"
 # example:


### PR DESCRIPTION
This change will only work if the basename of the archive follows the `name-version.extension` format. I didn't find anything better that would work more consistently (checking for occurence in the whole path using `in` and then getting the extension by using pathlib wouldn't work - parts of the version would be included in the extension). In the worst case scenario, it fallbacks to the previous solution - using `.tar.gz` as the default.

`SpecFile.get_archive()` could be used but currently rebase-helper assumes that Source0 is always the archive (which is incorrect, see https://github.com/rebase-helper/rebase-helper/issues/561 )

Any other ideas?

Resolves: #358 