### PR TITLE
Move user-docs to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ## Features
 * Packit service now submits builds in [copr](https://copr.fedorainfracloud.org) and once they're done it adds a GitHub status and comment with instructions how to install the builds.
-* Packit service is now configurable via [jobs](https://packit.dev/user-docs/configuration/#packit-service-jobs) defined in configuration file.
+* Packit service is now configurable via [jobs](https://packit.dev/docs/configuration/#packit-service-jobs) defined in configuration file.
 * Packit is now able to check GPG signatures of the upstream commits against configured fingerprints.
 * [CLI] `srpm` command now works also with [Source-git](https://packit.dev/source-git/).
 * Fedmsg parsing has been unified into a single `listen-to-fedmsg` command.
@@ -117,7 +117,7 @@ The first official release of packit!
 ## Features
 
 * `packit propose-update` brings a new upstream release into Fedora rawhide.
-  For more info, please [check out the documentation](https://packit.dev/user-docs/cli/propose-update/).
+  For more info, please [check out the documentation](https://packit.dev/docs/cli/propose-update/).
 
 * `packit watch-releases` listens to github events for new upstream releases.
   If an upstream project uses packit, it would bring the upstream release into

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This list contains workflows covered by packit tool and links to the documentati
 
 ## Configuration
 
-Configuration file for packit is described [here](http://packit.dev/docs]/configuration/).
+Configuration file for packit is described [here](http://packit.dev/docs/configuration/).
 
 TL;DR
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For the run-down of the planned work, please see the task-list below.
 
 * [ ] E2E workflow for getting upstream releases into Fedora using packit CLI.
   * [x] Bring new upstream releases into Fedora rawhide as dist-git pull
-        requests. ([propose-update](https://packit.dev/user-docs/cli/propose-update/) command included in 0.1.0 release)
+        requests. ([propose-update](https://packit.dev/docs/cli/propose-update/) command included in 0.1.0 release)
   * [x] Build the change once it's merged. #137
   * [x] Send new downstream changes back to upstream. (so the spec files are in
         sync) #145
@@ -47,16 +47,16 @@ For the run-down of the planned work, please see the task-list below.
 
 This list contains workflows covered by packit tool and links to the documentation.
 
-* [Update Fedora dist-git with an upstream release.](https://packit.dev/user-docs/cli/propose-update/)
-* [Build content of a Fedora dist-git branch in koji.](https://packit.dev/user-docs/cli/build/)
-* [Create a bodhi update.](https://packit.dev/user-docs/cli/create-bodhi-update/)
-* [Create a SRPM from the current content in the upstream repository.](https://packit.dev/user-docs/cli/srpm/)
-* [Sync content of the Fedora dist-git repo into the upstream repository.](https://packit.dev/user-docs/cli/sync-from-downstream/)
+* [Update Fedora dist-git with an upstream release.](https://packit.dev/docs/cli/propose-update/)
+* [Build content of a Fedora dist-git branch in koji.](https://packit.dev/docs/cli/build/)
+* [Create a bodhi update.](https://packit.dev/docs/cli/create-bodhi-update/)
+* [Create a SRPM from the current content in the upstream repository.](https://packit.dev/docs]/cli/srpm/)
+* [Sync content of the Fedora dist-git repo into the upstream repository.](https://packit.dev/docs]/cli/sync-from-downstream/)
 
 
 ## Configuration
 
-Configuration file for packit is described [here](http://packit.dev/user-docs/configuration/).
+Configuration file for packit is described [here](http://packit.dev/docs]/configuration/).
 
 TL;DR
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This list contains workflows covered by packit tool and links to the documentati
 * [Update Fedora dist-git with an upstream release.](https://packit.dev/docs/cli/propose-update/)
 * [Build content of a Fedora dist-git branch in koji.](https://packit.dev/docs/cli/build/)
 * [Create a bodhi update.](https://packit.dev/docs/cli/create-bodhi-update/)
-* [Create a SRPM from the current content in the upstream repository.](https://packit.dev/docs]/cli/srpm/)
+* [Create a SRPM from the current content in the upstream repository.](https://packit.dev/docs/cli/srpm/)
 * [Sync content of the Fedora dist-git repo into the upstream repository.](https://packit.dev/docs/cli/sync-from-downstream/)
 
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This list contains workflows covered by packit tool and links to the documentati
 * [Build content of a Fedora dist-git branch in koji.](https://packit.dev/docs/cli/build/)
 * [Create a bodhi update.](https://packit.dev/docs/cli/create-bodhi-update/)
 * [Create a SRPM from the current content in the upstream repository.](https://packit.dev/docs]/cli/srpm/)
-* [Sync content of the Fedora dist-git repo into the upstream repository.](https://packit.dev/docs]/cli/sync-from-downstream/)
+* [Sync content of the Fedora dist-git repo into the upstream repository.](https://packit.dev/docs/cli/sync-from-downstream/)
 
 
 ## Configuration

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,1 +1,1 @@
-The content of this document was moved to our website: https://packit.dev/user-docs/architecture/
+The content of this document was moved to our website: https://packit.dev/docs/architecture/

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -1,1 +1,1 @@
-The content of this document was moved to our website: https://packit.dev/user-docs/actions/
+The content of this document was moved to our website: https://packit.dev/docs/actions/

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,1 +1,1 @@
-The content of this document was moved to our website: https://packit.dev/user-docs/cli/build/
+The content of this document was moved to our website: https://packit.dev/docs/cli/build/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,1 +1,1 @@
-The content of this document was moved to our website: https://packit.dev/user-docs/configuration/
+The content of this document was moved to our website: https://packit.dev/docs/configuration/

--- a/docs/create_bodhi_update.md
+++ b/docs/create_bodhi_update.md
@@ -1,1 +1,1 @@
-The content of this document was moved to our website: https://packit.dev/user-docs/cli/create-bodhi-update/
+The content of this document was moved to our website: https://packit.dev/docs/cli/create-bodhi-update/

--- a/docs/how-to-source-git.md
+++ b/docs/how-to-source-git.md
@@ -1,1 +1,1 @@
-The content of this document was moved to our website: https://packit.dev/user-docs/how-to-source-git/
+The content of this document was moved to our website: https://packit.dev/docs/how-to-source-git/

--- a/docs/propose_update.md
+++ b/docs/propose_update.md
@@ -1,1 +1,1 @@
-The content of this document was moved to our website: https://packit.dev/user-docs/cli/propose-update/
+The content of this document was moved to our website: https://packit.dev/docs/cli/propose-update/

--- a/docs/srpm.md
+++ b/docs/srpm.md
@@ -1,1 +1,1 @@
-The content of this document was moved to our website: https://packit.dev/user-docs/cli/srpm/
+The content of this document was moved to our website: https://packit.dev/docs/cli/srpm/

--- a/docs/sync-from-downstream.md
+++ b/docs/sync-from-downstream.md
@@ -1,1 +1,1 @@
-The content of this document was moved to our website: https://packit.dev/user-docs/cli/sync-from-downstream/
+The content of this document was moved to our website: https://packit.dev/docs/cli/sync-from-downstream/

--- a/packit/actions.py
+++ b/packit/actions.py
@@ -31,7 +31,7 @@ class ActionName(Enum):
     implementation.
 
     New action needs to be added here and to the table in the
-    `https://github.com/packit-service/packit.dev/content/user-docs/actions.md`.
+    `https://github.com/packit-service/packit.dev/content/docs/actions.md`.
     (Some values are also used in tests:
     - tests/unit/test_config.py
     - tests/unit/test_actions.py

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -58,7 +58,7 @@ COPR2GITHUB_STATE = {
 }
 
 PACKIT_CONFIG_TEMPLATE = """# See the documentation for more information:
-# https://packit.dev/user-docs/configuration/
+# https://packit.dev/docs/configuration/
 
 specfile_path: {downstream_package_name}.spec
 


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

This pull request changes references from `https://packit.dev/user-docs` to `https://packit.dev/docs`

requires: https://github.com/packit-service/packit.dev/pull/25