### PR TITLE
Allow to (not) wait for dist-git build

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -347,12 +347,13 @@ class PackitAPI:
                 archive = self.dg.download_upstream_archive()
                 self.dg.upload_to_lookaside_cache(str(archive))
 
-    def build(self, dist_git_branch: str, scratch: bool = False):
+    def build(self, dist_git_branch: str, scratch: bool = False, nowait: bool = False):
         """
         Build component in koji
 
         :param dist_git_branch: ref in dist-git
         :param scratch: should the build be a scratch build?
+        :param nowait: don't wait on build?
         """
         logger.info(f"Using {dist_git_branch!r} dist-git branch")
 
@@ -365,7 +366,7 @@ class PackitAPI:
         self.dg.update_branch(dist_git_branch)
         self.dg.checkout_branch(dist_git_branch)
 
-        self.dg.build(scratch=scratch)
+        self.dg.build(scratch=scratch, nowait=nowait)
 
     def create_update(
         self,

--- a/packit/cli/build.py
+++ b/packit/cli/build.py
@@ -46,10 +46,11 @@ logger = logging.getLogger(__file__)
 @click.option(
     "--scratch", is_flag=True, default=False, help="Submit a scratch koji build"
 )
+@click.option("--nowait", is_flag=True, default=False, help="Don't wait on build")
 @click.argument("path_or_url", type=LocalProjectParameter(), default=getcwd())
 @pass_config
 @cover_packit_exception
-def build(config, dist_git_path, dist_git_branch, scratch, path_or_url):
+def build(config, dist_git_path, dist_git_branch, scratch, nowait, path_or_url):
     """
     Build selected upstream project in Fedora.
 
@@ -61,4 +62,4 @@ def build(config, dist_git_path, dist_git_branch, scratch, path_or_url):
     api = get_packit_api(
         config=config, dist_git_path=dist_git_path, local_project=path_or_url
     )
-    api.build(dist_git_branch, scratch=scratch)
+    api.build(dist_git_branch, scratch=scratch, nowait=nowait)

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -276,14 +276,15 @@ class DistGit(PackitRepositoryBase):
         # TODO: remove branches from merged PRs
         raise NotImplementedError("not implemented yet")
 
-    def build(self, scratch: bool = False):
+    def build(self, scratch: bool = False, nowait: bool = False):
         """
         Perform a `fedpkg build` in the repository
 
         :param scratch: should the build be a scratch build?
+        :param nowait: don't wait on build?
         """
         fpkg = FedPKG(directory=self.local_project.working_dir)
-        fpkg.build(scratch=scratch)
+        fpkg.build(scratch=scratch, nowait=nowait)
 
     def create_bodhi_update(
         self,

--- a/packit/fedpkg.py
+++ b/packit/fedpkg.py
@@ -54,10 +54,12 @@ class FedPKG:
             fail=fail,
         )
 
-    def build(self, scratch: bool = False):
-        cmd = [self.fedpkg_exec, "build", "--nowait"]
+    def build(self, scratch: bool = False, nowait: bool = False):
+        cmd = [self.fedpkg_exec, "build"]
         if scratch:
             cmd.append("--scratch")
+        if nowait:
+            cmd.append("--nowait")
         out = run_command(
             cmd=cmd,
             cwd=self.directory,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,7 +147,7 @@ def mock_remote_functionality(distgit: Path, upstream: Path):
         push_to_fork=lambda *args, **kwargs: None,
         # let's not hammer the production lookaside cache webserver
         is_archive_in_lookaside_cache=lambda archive_path: False,
-        build=lambda scratch: None,
+        build=lambda scratch, nowait: None,
         local_project=dglp,
     )
 


### PR DESCRIPTION
Resolves #411

This changes `packit build` to wait for the build by default, since that's also the `fedpkg build`'s default behavior. 