### PR TITLE
Add support create_pr option into packit.yaml

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,6 +10,7 @@ upstream_project_name: packitos
 downstream_package_name: packit
 current_version_command: ["python3", "setup.py", "--version"]
 create_tarball_command: ["python3", "setup.py", "sdist", "--dist-dir", "."]
+create_pr: false
 jobs:
 - job: propose_downstream
   trigger: release

--- a/packit/api.py
+++ b/packit/api.py
@@ -150,6 +150,7 @@ class PackitAPI:
         self.up.allowed_gpg_keys = self.dg.get_allowed_gpg_keys_from_downstream_config()
 
         upstream_ref = upstream_ref or self.package_config.upstream_ref
+        create_pr = create_pr or self.package_config.create_pr
         self.up.run_action(actions=ActionName.post_upstream_clone)
 
         full_version = version or self.up.get_version()

--- a/packit/config.py
+++ b/packit/config.py
@@ -358,6 +358,7 @@ class PackageConfig(BaseConfig):
         actions: Dict[ActionName, str] = None,
         upstream_ref: Optional[str] = None,
         allowed_gpg_keys: Optional[List[str]] = None,
+        create_pr: Optional[bool] = True,
     ):
         self.specfile_path: Optional[str] = specfile_path
         self.synced_files: SyncFilesConfig = synced_files or SyncFilesConfig([])
@@ -372,6 +373,7 @@ class PackageConfig(BaseConfig):
         self.actions = actions or {}
         self.upstream_ref: Optional[str] = upstream_ref
         self.allowed_gpg_keys = allowed_gpg_keys
+        self.create_pr = create_pr
 
         # command to generate a tarball from the upstream repo
         # uncommitted changes will not be present in the archive
@@ -416,6 +418,7 @@ class PackageConfig(BaseConfig):
             and self.create_tarball_command == other.create_tarball_command
             and self.actions == other.actions
             and self.allowed_gpg_keys == other.allowed_gpg_keys
+            and self.create_pr == other.create_pr
         )
 
     @property
@@ -463,6 +466,7 @@ class PackageConfig(BaseConfig):
         upstream_ref = nested_get(raw_dict, "upstream_ref")
 
         allowed_gpg_keys = raw_dict.get("allowed_gpg_keys", None)
+        create_pr = raw_dict.get("create_pr", True)
 
         pc = PackageConfig(
             specfile_path=specfile_path,
@@ -480,6 +484,7 @@ class PackageConfig(BaseConfig):
             current_version_command=current_version_command,
             upstream_ref=upstream_ref,
             allowed_gpg_keys=allowed_gpg_keys,
+            create_pr=create_pr,
         )
         return pc
 

--- a/tests/data/upstream_git/.packit.json
+++ b/tests/data/upstream_git/.packit.json
@@ -5,4 +5,5 @@
   ],
   "upstream_project_name": "beerware",
   "downstream_package_name": "beer",
+  "create_pr": false,
 }

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -134,6 +134,7 @@ def test_package_config_equal(job_config_simple):
         ),
         jobs=[job_config_simple],
         downstream_package_name="package",
+        create_pr=True,
     ) == PackageConfig(
         specfile_path="fedora/package.spec",
         synced_files=SyncFilesConfig(
@@ -141,6 +142,7 @@ def test_package_config_equal(job_config_simple):
         ),
         jobs=[job_config_simple],
         downstream_package_name="package",
+        create_pr=True,
     )
 
 
@@ -193,6 +195,7 @@ def test_package_config_equal(job_config_simple):
                 ]
             ),
             jobs=[get_job_config_full()],
+            create_pr=False,
         ),
     ],
 )
@@ -209,6 +212,7 @@ def test_package_config_not_equal(not_equal_package_config):
                 ]
             ),
             jobs=[j],
+            create_pr=True,
         )
         == not_equal_package_config
     )
@@ -304,6 +308,7 @@ def test_package_config_parse_error(raw):
                 "synced_files": ["fedora/package.spec"],
                 "jobs": [get_job_config_dict_full()],
                 "downstream_package_name": "package",
+                "create_pr": False,
             },
             PackageConfig(
                 specfile_path="fedora/package.spec",
@@ -316,6 +321,7 @@ def test_package_config_parse_error(raw):
                 ),
                 jobs=[get_job_config_full()],
                 downstream_package_name="package",
+                create_pr=False,
             ),
         ),
         (
@@ -457,6 +463,7 @@ def test_dist_git_package_url():
         "dist_git_namespace": "awesome",
         "synced_files": ["fedora/foobar.spec"],
         "specfile_path": "fedora/package.spec",
+        "create_pr": False,
     }
     new_pc = PackageConfig.get_from_dict(di)
     pc = PackageConfig(
@@ -469,12 +476,14 @@ def test_dist_git_package_url():
             ]
         ),
         specfile_path="fedora/package.spec",
+        create_pr=False,
     )
     assert new_pc.specfile_path.endswith("fedora/package.spec")
     assert pc.specfile_path.endswith("fedora/package.spec")
     assert pc == new_pc
     assert pc.dist_git_package_url == "https://packit.dev/awesome/packit.git"
     assert new_pc.dist_git_package_url == "https://packit.dev/awesome/packit.git"
+    assert not pc.create_pr
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

This pull request adds functionality to determine if create_pr is allowed from CLI or from `packit.yaml`.
Adds `create_pr` into `packit.yaml` file.
This is needed for `packit-service` if we want to directly push into dist-git.
It also changed `packit` configuration file and adds there `create_pr` to False, so we can push changes directly into dist-git branch.

