### PR TITLE
make fedpkg work in openshift

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -261,8 +261,7 @@ class PackitAPI:
                     dist_git_branch=dist_git_branch,
                 )
             else:
-                logger.info(f"Pushing changes to '{dist_git_branch}' distgit branch.")
-                self.dg.local_project.git_repo.remote().push()
+                self.dg.push(refspec=f"HEAD:{dist_git_branch}")
         finally:
             if not use_local_content:
                 self.up.local_project.git_repo.git.checkout(current_up_branch)
@@ -331,7 +330,7 @@ class PackitAPI:
             self.up.commit(title=commit_msg, msg=description)
 
             # the branch may already be up, let's push forcefully
-            source_branch, fork_username = self.up.push(
+            source_branch, fork_username = self.up.push_to_fork(
                 self.up.local_project.ref,
                 fork=fork,
                 force=True,

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -182,9 +182,7 @@ class DistGit(PackitRepositoryBase):
             )
 
         try:
-            self.local_project.git_repo.remote(fork_remote_name).push(
-                refspec=branch_name, force=force
-            )
+            self.push(refspec=branch_name, remote_name=fork_remote_name, force=force)
         except git.GitError as ex:
             msg = (
                 f"Unable to push to remote {fork_remote_name} using branch {branch_name}, "

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -90,7 +90,8 @@ class DistGit(PackitRepositoryBase):
                 )
             else:
                 tmpdir = tempfile.mkdtemp(prefix="packit-dist-git")
-                f = FedPKG(self.fas_user, tmpdir)
+                f = FedPKG(fas_username=self.fas_user, directory=tmpdir)
+                f.init_ticket(self.config.keytab_path)
                 f.clone(
                     self.package_config.downstream_package_name,
                     tmpdir,
@@ -262,8 +263,8 @@ class DistGit(PackitRepositoryBase):
         """
         # TODO: can we check if the tarball is already uploaded so we don't have ot re-upload?
         logger.info("About to upload to lookaside cache")
-        f = FedPKG(self.fas_user, self.local_project.working_dir)
-        f.init_ticket()
+        f = FedPKG(fas_username=self.fas_user, directory=self.local_project.working_dir)
+        f.init_ticket(self.config.keytab_path)
         try:
             f.new_sources(sources=archive_path)
         except Exception as ex:
@@ -309,7 +310,10 @@ class DistGit(PackitRepositoryBase):
         :param nowait: don't wait on build?
         :param koji_target: koji target to pick (see `koji list-targets`)
         """
-        fpkg = FedPKG(directory=self.local_project.working_dir)
+        fpkg = FedPKG(
+            fas_username=self.fas_user, directory=self.local_project.working_dir
+        )
+        fpkg.init_ticket(self.config.keytab_path)
         fpkg.build(scratch=scratch, nowait=nowait, koji_target=koji_target)
 
     def create_bodhi_update(

--- a/packit/fedpkg.py
+++ b/packit/fedpkg.py
@@ -77,7 +77,14 @@ class FedPKG:
         )
 
     def clone(self, package_name: str, target_path: str, anonymous: bool = False):
-        cmd = [self.fedpkg_exec, "-q", "clone"]
+        """
+        clone a dist-git repo; this has to be done in current env
+        b/c we don't have the keytab in sandbox
+        """
+        cmd = [self.fedpkg_exec]
+        if self.fas_username:
+            cmd += ["--user", self.fas_username]
+        cmd += ["-q", "clone"]
         if anonymous:
             cmd += ["-a"]
         cmd += [package_name, target_path]
@@ -85,7 +92,7 @@ class FedPKG:
 
     def init_ticket(self, keytab: str = None):
         # TODO: this method has nothing to do with fedpkg, pull it out
-        if not keytab:
+        if not keytab and not self.fas_username:
             logger.info("won't be doing kinit, no credentials provided")
             return
         if keytab and Path(keytab).is_file():

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -23,7 +23,7 @@
 import logging
 import shutil
 from contextlib import contextmanager
-from typing import Optional, Union
+from typing import Optional, Union, Iterable
 
 import git
 from ogr.abstract import GitProject, GitService
@@ -322,6 +322,19 @@ class LocalProject:
         rem.fetch(f"{remote_ref}:{local_ref}")
         self.git_repo.create_head(local_branch, f"{remote_name}/{local_branch}")
         self.git_repo.branches[local_branch].checkout()
+
+    def push(
+        self, refspec: str, remote_name: str = "origin", force: bool = False
+    ) -> Iterable[git.PushInfo]:
+        """
+        push changes to a remote using provided refspec
+
+        :param refspec: e.g. "master", "HEAD:f30"
+        :param remote_name: name of the remote where we push
+        :param force: force push: yes or no?
+        :return: a list of git.remote.PushInfo objects - have fun
+        """
+        return self.git_repo.remote(name=remote_name).push(refspec=refspec, force=force)
 
     def __del__(self):
         self.clean()

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -157,7 +157,7 @@ class Upstream(PackitRepositoryBase):
         )
         return commits
 
-    def push(
+    def push_to_fork(
         self,
         branch_name: str,
         force: bool = False,
@@ -208,9 +208,7 @@ class Upstream(PackitRepositoryBase):
                 remote_name = "origin"
         logger.info(f"Pushing to remote {remote_name} using branch {branch_name}.")
         try:
-            self.local_project.git_repo.remote(remote_name).push(
-                refspec=branch_name, force=force
-            )
+            self.push(refspec=branch_name, force=force, remote_name=remote_name)
         except git.GitError as ex:
             msg = (
                 f"Unable to push to remote {remote_name} using branch {branch_name}, "

--- a/packit/utils.py
+++ b/packit/utils.py
@@ -65,7 +65,7 @@ def run_command(cmd, error_message=None, cwd=None, fail=True, output=False):
     logger.debug("cmd = '%s'", " ".join(cmd))
 
     cwd = cwd or str(Path.cwd())
-    error_message = error_message or cmd[0]
+    error_message = error_message or f"Command {cmd} failed."
 
     shell = subprocess.run(
         cmd,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,11 +31,11 @@ from typing import Tuple
 import pytest
 from flexmock import flexmock
 from gnupg import GPG
-from rebasehelper.specfile import SpecFile
-
 from ogr.abstract import PullRequest, PRStatus
 from ogr.services.github import GithubService, GithubProject
 from ogr.services.pagure import PagureProject, PagureService
+from rebasehelper.specfile import SpecFile
+
 from packit.api import PackitAPI
 from packit.config import get_local_package_config
 from packit.distgit import DistGit
@@ -177,9 +177,10 @@ def mock_patching():
 def upstream_distgit_remote(tmpdir) -> Tuple[Path, Path, Path]:
     t = Path(str(tmpdir))
 
-    u_remote = t / "upstream_remote"
-    u_remote.mkdir()
-    subprocess.check_call(["git", "init", "--bare", "."], cwd=u_remote)
+    u_remote_path = t / "upstream_remote"
+    u_remote_path.mkdir(parents=True, exist_ok=True)
+
+    subprocess.check_call(["git", "init", "--bare", "."], cwd=u_remote_path)
 
     u = t / "upstream_git"
     shutil.copytree(UPSTREAM, u)
@@ -187,10 +188,10 @@ def upstream_distgit_remote(tmpdir) -> Tuple[Path, Path, Path]:
 
     d = t / "dist_git"
     shutil.copytree(DISTGIT, d)
-    initiate_git_repo(d, push=True, upstream_remote=str(u_remote))
+    initiate_git_repo(d, push=True, upstream_remote=str(u_remote_path))
     prepare_dist_git_repo(d)
 
-    return u, d, u_remote
+    return u, d, u_remote_path
 
 
 @pytest.fixture()


### PR DESCRIPTION
Changes:
* call kinit before doing fedpkg clone - this is needed inside packit service
* push explicitly and show errors if there are some - in packit service, we don't have branch tracking set up implicitly

Fixes #431