### PR TITLE
Requires python3-ogr

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -40,6 +40,7 @@ projects into Fedora operating system.
 
 %package -n     python3-%{real_name}
 Summary:        %{summary}
+Requires:       python3-ogr
 %{?python_provide:%python_provide python3-%{real_name}}
 
 %description -n python3-%{real_name}


### PR DESCRIPTION
Addressing:
```
$ packit status
Traceback (most recent call last):
  File "/usr/bin/packit", line 11, in <module>
    load_entry_point('packitos==0.2.0', 'console_scripts', 'packit')()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2793, in load_entry_point
    return ep.load()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2411, in load
    return self.resolve()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2417, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/lib/python3.7/site-packages/packit/cli/packit_base.py", line 6, in <module>
    from packit.cli.build import build
  File "/usr/lib/python3.7/site-packages/packit/cli/build.py", line 6, in <module>
    from packit.cli.types import LocalProjectParameter
  File "/usr/lib/python3.7/site-packages/packit/cli/types.py", line 3, in <module>
    from packit.local_project import LocalProject
  File "/usr/lib/python3.7/site-packages/packit/local_project.py", line 8, in <module>
    from ogr.abstract import GitProject, GitService
ModuleNotFoundError: No module named 'ogr.abstract'; 'ogr' is not a package
```