### PR TITLE
[CLI:status] Show also latest rawhide build

### DIFF
--- a/packit/status.py
+++ b/packit/status.py
@@ -123,18 +123,11 @@ class Status:
         b = BodhiClient()
         # { koji-target: "latest-build-nvr"}
         builds_d = b.latest_builds(self.dg.package_config.downstream_package_name)
-        branches = self.dg.local_project.git_project.get_branches()
-        logger.debug("Latest koji builds fetched.")
+        logger.debug(f"Latest Koji builds fetched (from Bodhi): {builds_d}.")
         builds: Dict = {}
-        for branch in branches:
-            # there is no master tag in koji
-            if branch == "master":
-                continue
-            koji_tag = f"{branch}-updates-candidate"
-            try:
-                builds[branch] = builds_d[koji_tag]
-            except KeyError:
-                logger.info(f"There are no builds for branch {branch}")
+        for tag, nvr in builds_d.items():
+            if tag.endswith("-updates-candidate"):
+                builds[tag[: -len("-updates-candidate")]] = nvr
         return builds
 
     def get_updates(self, number_of_updates: int = 3) -> List:


### PR DESCRIPTION
Previously:
```
Latest Koji builds:
f29: python-ogr-0.5.0-1.fc29
f30: python-ogr-0.6.0-1.fc30
```
Now:
```
Latest Koji builds:
f29: python-ogr-0.5.0-1.fc29
f30: python-ogr-0.6.0-1.fc30
f31: python-ogr-0.6.0-1.fc31
```