### PR TITLE
Add support for comments

### DIFF
--- a/packit/config.py
+++ b/packit/config.py
@@ -224,6 +224,7 @@ class JobType(Enum):
     add_to_whitelist = "add_to_whitelist"
     tests = "tests"
     report_test_results = "report_test_results"
+    pull_request_action = "pull_request_action"
 
 
 class JobTriggerType(Enum):
@@ -232,6 +233,7 @@ class JobTriggerType(Enum):
     commit = "commit"
     installation = "installation"
     testing_farm_results = "testing_farm_results"
+    comment = "comment"
 
 
 class JobNotifyType(Enum):


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

This pull request only adds variables for new Job into packit-service.
If the user adds a comment like `/packit copr-build` then JobType `pull_request_action` is called in `packit-service`. JobTrigger is called `comment`