### PR TITLE
simplier ansible scripts + regeneration target in makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ RUN dnf -y install ansible
 
 ENV ANSIBLE_STDOUT_CALLBACK=debug
 
-COPY files/install-requirements.yaml packit.spec ./
-RUN ansible-playbook -v -c local -i localhost, ./install-requirements.yaml
+COPY files/*.yaml files/
+COPY files/tasks/*.yaml files/tasks/
+COPY *.spec .
+RUN  ansible-playbook -v -c local -i localhost, files/install-requirements.yaml
 
 WORKDIR /src

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CONTAINER_NAME=packit
 TESTS_INTEGRATION_PATH=tests/integration
 TEST_DATA_PATH=$(TESTS_INTEGRATION_PATH)/test_data
-CONTAINER_RUN=podman run --rm -ti -v $(CURDIR):/src:Z $(CONTAINER_NAME)
+CONTAINER_RUN=podman run --rm -ti -v $(CURDIR):/src --security-opt label=disable $(CONTAINER_NAME)
 TEST_TARGET := ./tests
 
 test_container:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 CONTAINER_NAME=packit
-CONTAINER_RUN=podman run --rm -ti -v /tmp/packit:/src:Z $(CONTAINER_NAME)
-TEST_TARGET := ./tests/
+TESTS_INTEGRATION_PATH=tests/integration
+TEST_DATA_PATH=$(TESTS_INTEGRATION_PATH)/test_data
+CONTAINER_RUN=podman run --rm -ti -v $(CURDIR):/src:Z $(CONTAINER_NAME)
+TEST_TARGET := ./tests
 
 test_container:
 	podman build --tag $(CONTAINER_NAME) .
@@ -8,6 +10,7 @@ test_container:
 
 test_container_remove:
 	podman image rm $(CONTAINER_NAME)
+
 install:
 	pip3 install --user .
 
@@ -16,5 +19,8 @@ check:
 	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 python3 -m pytest --verbose --showlocals --cov=packit --cov-report=term-missing $(TEST_TARGET)
 
 check_in_container: test_container
-	rsync -a $(CURDIR)/ /tmp/packit
 	$(CONTAINER_RUN) bash -c "pip3 install .; make check TEST_TARGET=$(TEST_TARGET)"
+
+
+check_in_container_regenerate_data: test_container
+	$(CONTAINER_RUN) bash -c "pip3 install .;make check TEST_TARGET=$(TESTS_INTEGRATION_PATH) GITHUB_TOKEN=${GITHUB_TOKEN} PAGURE_TOKEN=${PAGURE_TOKEN}"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,14 +11,12 @@ Vagrant.configure("2") do |config|
     end
 
     config.vm.provision "shell", inline: <<-SHELL
-        cd /vagrant
-        cp files/install-requirements.yaml .
         dnf -y install ansible || true
     SHELL
 
     config.vm.provision :ansible_local do |ansible|
 	    ansible.verbose = "v"
-	    ansible.playbook = "./install-requirements.yaml"
+	    ansible.playbook = "files/install-requirements.yaml"
 	    ansible.become = true
     end
 

--- a/files/install-requirements.yaml
+++ b/files/install-requirements.yaml
@@ -1,45 +1,15 @@
 ---
 - name: Install dependencies for packit.
   hosts: all
+  vars:
+    project_dir: "{{ playbook_dir }}/.."
   tasks:
-  - name: Install generic RPM packages
-    dnf:
-      name:
-      - make
-      - git
-      - dnf-utils
-      - python3-pip
-
-  - name: Install test rpm dependencies
-    dnf:
-      name:
-      - python3-flexmock
-      - python3-pytest
-      - python3-pytest-cov
-      state: present
-
-  - name: Install runtime RPM deps
-    dnf:
-      name:
-        - fedpkg
-        - rpmdevtools
-        - python3-bodhi-client
-        - python3-cccolutils
-        - rpmdevtools
-      state: present
-
-  - name: Install build RPM dependencies
-    command: dnf -y builddep packit.spec
-
-  - name: Pip install sandcastle, our sandboxing tech (needed when running as a service)
-    pip:
-      name: git+https://github.com/packit-service/sandcastle
-
+  - include_tasks: tasks/generic-dnf-requirements.yaml
+  - include_tasks: tasks/python-compile-deps.yaml
+  - include_tasks: tasks/ogr-from-master.yaml
+  - include_tasks: tasks/rpm-test-deps.yaml
+  - include_tasks: tasks/sandcastle-master.yaml
+  - include_tasks: tasks/configure-git.yaml
   - name: Pip install pre-commit
     pip:
       name: pre-commit
-
-  - name: "set up git: email"
-    command: git config --global user.email test@example.com
-  - name: "set up git: name"
-    command: git config --global user.name "Packit Test Suite"

--- a/files/tasks/build-rpm-deps.yaml
+++ b/files/tasks/build-rpm-deps.yaml
@@ -1,0 +1,6 @@
+---
+- name: Install build RPM dependencies
+  command: dnf -y builddep packit.spec
+  args:
+    chdir: '{{ project_dir }}'
+  become: true

--- a/files/tasks/configure-git.yaml
+++ b/files/tasks/configure-git.yaml
@@ -1,0 +1,5 @@
+---
+- name: "set up git: email"
+  command: git config --global user.email test@example.com
+- name: "set up git: name"
+  command: git config --global user.name "Packit Test Suite"

--- a/files/tasks/generic-dnf-requirements.yaml
+++ b/files/tasks/generic-dnf-requirements.yaml
@@ -9,4 +9,5 @@
     - rpmdevtools
     - python3-bodhi-client
     - fedpkg
+    - python3-cccolutils
   become: true

--- a/files/tasks/install-packit.yaml
+++ b/files/tasks/install-packit.yaml
@@ -1,0 +1,5 @@
+---
+- name: Install packit from {{ project_dir }}
+  pip:
+    name: '{{ project_dir }}'
+  become: true

--- a/files/tasks/ogr-from-master.yaml
+++ b/files/tasks/ogr-from-master.yaml
@@ -1,0 +1,5 @@
+---
+- name: Pip install ogr from master
+  pip:
+    name: git+https://github.com/packit-service/ogr
+  become: true

--- a/files/tasks/rpm-test-deps.yaml
+++ b/files/tasks/rpm-test-deps.yaml
@@ -1,0 +1,9 @@
+---
+- name: Install test rpm dependencies
+  dnf:
+    name:
+    - python3-flexmock
+    - python3-pytest
+    - python3-pytest-cov
+    state: present
+  become: true

--- a/files/tasks/sandcastle-master.yaml
+++ b/files/tasks/sandcastle-master.yaml
@@ -1,0 +1,5 @@
+---
+- name: Pip install sandcastle, our sandboxing tech (needed when running as a service)
+  pip:
+    name: git+https://github.com/packit-service/sandcastle
+  become: true

--- a/files/zuul-install-requirements-git-master.yaml
+++ b/files/zuul-install-requirements-git-master.yaml
@@ -4,8 +4,4 @@
   tasks:
   - include_tasks: tasks/generic-dnf-requirements.yaml
   - include_tasks: tasks/python-compile-deps.yaml
-
-  - name: Pip install ogr from master
-    pip:
-      name: git+https://github.com/packit-service/ogr
-    become: true
+  - include_tasks: tasks/ogr-from-master.yaml

--- a/files/zuul-install-requirements-rpms.yaml
+++ b/files/zuul-install-requirements-rpms.yaml
@@ -4,17 +4,4 @@
   tasks:
   - include_tasks: tasks/zuul-project-setup.yaml
   - include_tasks: tasks/generic-dnf-requirements.yaml
-  - name: Install runtime RPM deps
-    dnf:
-      name:
-        - fedpkg
-        - rpmdevtools
-        - python3-bodhi-client
-        - python3-cccolutils
-      state: present
-    become: true
-  - name: Install build RPM dependencies
-    command: dnf -y builddep packit.spec
-    args:
-      chdir: '{{ project_dir }}'
-    become: true
+  - include_tasks: tasks/build-rpm-deps.yaml

--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -3,30 +3,10 @@
   hosts: all
   tasks:
   - include_tasks: tasks/zuul-project-setup.yaml
-  - name: Install test rpm dependencies
-    dnf:
-      name:
-      - python3-flexmock
-      - python3-pytest
-      - python3-pytest-cov
-      state: present
-    become: true
-
-  - name: "set up git: email"
-    command: git config --global user.email test@example.com
-  - name: "set up git: name"
-    command: git config --global user.name "Packit Test Suite"
-
-  - name: Pip install sandcastle, our sandboxing tech (needed when running as a service)
-    pip:
-      name: git+https://github.com/packit-service/sandcastle
-    become: true
-
-  - name: Install packit from {{ project_dir }}
-    pip:
-      name: '{{ project_dir }}'
-    become: true
-
+  - include_tasks: tasks/rpm-test-deps.yaml
+  - include_tasks: tasks/sandcastle-master.yaml
+  - include_tasks: tasks/install-packit.yaml
+  - include_tasks: tasks/configure-git.yaml
   - name: Run tests
     command: make check
     args:

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -215,5 +215,7 @@ def test_github_app(upstream_instance, tmpdir):
         str(tmpdir)
     )
     ups.config = Config.get_user_config()
-
-    assert ups.local_project.git_service.token == "test"
+    if os.environ.get("GITHUB_TOKEN"):
+        assert os.environ.get("GITHUB_TOKEN") == ups.local_project.git_service.token
+    else:
+        assert ups.local_project.git_service.token == "test"


### PR DESCRIPTION
## FIX several issues 
 - simplify ansible scripts, avoid duplication
 - same enviroment for make check in container as zuul check ogr from master
 - regenerate ``test_data`` in container to ensure you have clean env
 - fix vagrant  according to these changes
 - fix dockerfile according to these changes