### PR TITLE
pass src_dir as a relative path to up.srpm()

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -446,15 +446,22 @@ class PackitAPI:
 
         upstream_ref = upstream_ref or self.package_config.upstream_ref
 
+        if self.up.running_in_service():
+            relative_to = Path(self.config.command_handler_work_dir)
+        else:
+            relative_to = Path.cwd()
+
         if upstream_ref:
             # source-git code: fetch the tarball and don't check out the upstream ref
             self.up.fetch_upstream_archive()
-            source_dir = self.up.absolute_specfile_dir
+            source_dir = self.up.absolute_specfile_dir.relative_to(relative_to)
         else:
             # upstream repo: create the archive
             archive = self.up.create_archive(version=current_git_describe_version)
             self.up.specfile.set_tag("Source0", archive)
-            source_dir = self.up.local_project.working_dir
+            source_dir = Path(self.up.local_project.working_dir).relative_to(
+                relative_to
+            )
 
         commit = self.up.local_project.git_repo.active_branch.commit.hexsha[:8]
 

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -24,7 +24,7 @@ import os
 import re
 import shutil
 from pathlib import Path
-from typing import Optional, List, Tuple
+from typing import Optional, List, Tuple, Union
 
 import git
 from packaging import version
@@ -504,7 +504,10 @@ class Upstream(PackitRepositoryBase):
         return archive_name
 
     def create_srpm(
-        self, srpm_path: str = None, source_dir: str = None, srpm_dir: str = None
+        self,
+        srpm_path: str = None,
+        source_dir: Union[str, Path] = None,
+        srpm_dir: str = None,
     ) -> Path:
         """
         Create SRPM from the actual content of the repo
@@ -517,7 +520,6 @@ class Upstream(PackitRepositoryBase):
         if self.running_in_service():
             srpm_dir = "."
             rpmbuild_dir = "."
-            source_dir = "."
         else:
             srpm_dir = srpm_dir or os.getcwd()
             rpmbuild_dir = str(self.absolute_specfile_dir)


### PR DESCRIPTION
This should fix a case in the service when the specfile is not in the root of the git repo.