### PR TITLE
Replace version command with --version option

### DIFF
--- a/packit/cli/packit_base.py
+++ b/packit/cli/packit_base.py
@@ -48,6 +48,9 @@ logger = logging.getLogger("packit")
     is_flag=True,
     help="Do not perform any remote changes (pull requests or comments).",
 )
+@click.version_option(
+    version=get_distribution("packitos").version, message="%(version)s"
+)
 @click.pass_context
 def packit_base(ctx, debug, fas_user, keytab, dry_run):
     """Integrate upstream open source projects into Fedora operating system."""
@@ -66,13 +69,6 @@ def packit_base(ctx, debug, fas_user, keytab, dry_run):
         logger.debug("logging set to INFO")
 
 
-@click.command("version")
-def version():
-    """Display the version."""
-    click.echo(get_distribution("packitos").version)
-
-
-packit_base.add_command(version)
 packit_base.add_command(update)
 packit_base.add_command(sync_from_downstream)
 packit_base.add_command(build)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -21,11 +21,11 @@
 # SOFTWARE.
 
 import pytest
+from pkg_resources import get_distribution
 
 from packit.cli.build import build
 from packit.cli.create_update import create_update
 from packit.cli.packit_base import packit_base
-from packit.cli.packit_base import version as cli_version
 from packit.cli.update import update
 from tests.spellbook import call_packit
 
@@ -36,22 +36,11 @@ def test_base_help():
     assert "Usage: packit [OPTIONS] COMMAND [ARGS]..." in result.output
 
 
-def test_base_version_direct():
-    # This test requires packit on pythonpath
-    result = call_packit(cli_version)
-    assert result.exit_code == 0
-
-
 def test_base_version():
     # This test requires packit on pythonpath
-    result = call_packit(parameters=["version"])
+    result = call_packit(parameters=["--version"])
     assert result.exit_code == 0
-    # TODO: figure out the correct version getter:
-    # version = get_version(root="../..", relative_to=__file__)
-    # name_ver = get_distribution(__name__).version
-    # packit_ver = get_distribution("packit").version
-    # packitos_ver = get_distribution("packitos").version
-    # assert version in result.output
+    assert result.output.strip() == get_distribution("packitos").version
 
 
 @pytest.mark.parametrize("cmd_function", [update, build, create_update])


### PR DESCRIPTION
Fixes: #375 

Do you guys agree with the position in help? I think it makes the most sense to have it next to `--help` option.