### PR TITLE
[utils.nested_get()] don't report returning default value

### DIFF
--- a/packit/utils.py
+++ b/packit/utils.py
@@ -218,8 +218,8 @@ def nested_get(d: dict, *keys, default=None) -> Any:
     for k in keys:
         try:
             response = response[k]
-        except (KeyError, AttributeError, TypeError) as ex:
-            logger.debug("can't obtain %s: %s", k, ex)
+        except (KeyError, AttributeError, TypeError):
+            # logger.debug("can't obtain %s: %s", k, ex)
             return default
     return response
 


### PR DESCRIPTION
`dict.get()` also does not report anything.

The reason is that I see a lot of these in the logs and I doubt they have any value
```
[DEBUG/ForkPoolWorker-1] can't obtain action: 'action'
[DEBUG/ForkPoolWorker-1] can't obtain number: 'number'
[DEBUG/ForkPoolWorker-1] can't obtain pull_request: 'pull_request'
[DEBUG/ForkPoolWorker-1] can't obtain release: 'release'
[DEBUG/ForkPoolWorker-1] can't obtain action: 'action'
```