### PR TITLE
Separate image for packit and for tests

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,5 +1,5 @@
-# pip3 install packit from this repo.
-# To build packit image on docker hub.
+# Packit (test) dependencies.
+# To run tests locally via 'make check_in_container'.
 
 FROM fedora:30
 
@@ -8,10 +8,10 @@ RUN dnf -y install ansible
 ENV ANSIBLE_STDOUT_CALLBACK=debug
 
 COPY files/tasks/*.yaml /files/tasks/
-COPY files/install-requirements.yaml /files/
+COPY files/*.yaml /files/
 COPY *.spec .
 
 RUN ansible-playbook -v -c local -i localhost, /files/install-requirements.yaml
-RUN pip3 install .
+RUN ansible-playbook -v -c local -i localhost, /files/install-tests-requirements.yaml
 
 WORKDIR /src

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,25 @@
-CONTAINER_NAME=packit
+TESTS_IMAGE=packit-tests
 TESTS_INTEGRATION_PATH=tests/integration
-TEST_DATA_PATH=$(TESTS_INTEGRATION_PATH)/test_data
-CONTAINER_RUN=podman run --rm -ti -v $(CURDIR):/src --security-opt label=disable $(CONTAINER_NAME)
-TEST_TARGET := ./tests
+TESTS_CONTAINER_RUN=podman run --rm -ti -v $(CURDIR):/src --security-opt label=disable $(TESTS_IMAGE)
+TESTS_TARGET := ./tests
 
-test_container:
-	podman build --tag $(CONTAINER_NAME) .
+tests_image:
+	podman build --tag $(TESTS_IMAGE) .
 	sleep 2
 
-test_container_remove:
-	podman image rm $(CONTAINER_NAME)
+tests_image_remove:
+	podman rmi $(TESTS_IMAGE)
 
 install:
 	pip3 install --user .
 
 check:
 	find . -name "*.pyc" -exec rm {} \;
-	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 python3 -m pytest --verbose --showlocals --cov=packit --cov-report=term-missing $(TEST_TARGET)
+	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 python3 -m pytest --verbose --showlocals --cov=packit --cov-report=term-missing $(TESTS_TARGET)
 
-check_in_container: test_container
-	$(CONTAINER_RUN) bash -c "pip3 install .; make check TEST_TARGET=$(TEST_TARGET)"
+check_in_container: tests_image
+	$(TESTS_CONTAINER_RUN) bash -c "pip3 install .; make check TESTS_TARGET=$(TESTS_TARGET)"
 
 
-check_in_container_regenerate_data: test_container
-	$(CONTAINER_RUN) bash -c "pip3 install .;make check TEST_TARGET=$(TESTS_INTEGRATION_PATH) GITHUB_TOKEN=${GITHUB_TOKEN} PAGURE_TOKEN=${PAGURE_TOKEN}"
+check_in_container_regenerate_data: tests_image
+	$(TESTS_CONTAINER_RUN) bash -c "pip3 install .;make check TESTS_TARGET=$(TESTS_INTEGRATION_PATH) GITHUB_TOKEN=${GITHUB_TOKEN} PAGURE_TOKEN=${PAGURE_TOKEN}"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TESTS_CONTAINER_RUN=podman run --rm -ti -v $(CURDIR):/src --security-opt label=d
 TESTS_TARGET := ./tests
 
 tests_image:
-	podman build --tag $(TESTS_IMAGE) .
+	podman build --tag $(TESTS_IMAGE) -f Dockerfile.tests .
 	sleep 2
 
 tests_image_remove:

--- a/files/install-requirements.yaml
+++ b/files/install-requirements.yaml
@@ -5,11 +5,5 @@
     project_dir: "{{ playbook_dir }}/.."
   tasks:
   - include_tasks: tasks/generic-dnf-requirements.yaml
+  - include_tasks: tasks/build-rpm-deps.yaml
   - include_tasks: tasks/python-compile-deps.yaml
-  - include_tasks: tasks/ogr-from-master.yaml
-  - include_tasks: tasks/rpm-test-deps.yaml
-  - include_tasks: tasks/sandcastle-master.yaml
-  - include_tasks: tasks/configure-git.yaml
-  - name: Pip install pre-commit
-    pip:
-      name: pre-commit

--- a/files/install-tests-requirements.yaml
+++ b/files/install-tests-requirements.yaml
@@ -1,0 +1,13 @@
+---
+- name: Install dependencies for packit tests.
+  hosts: all
+  vars:
+    project_dir: "{{ playbook_dir }}/.."
+  tasks:
+  - include_tasks: tasks/rpm-test-deps.yaml
+  - include_tasks: tasks/configure-git.yaml
+  - include_tasks: tasks/ogr-from-master.yaml
+  - include_tasks: tasks/sandcastle-master.yaml
+  - name: Pip install pre-commit
+    pip:
+      name: pre-commit


### PR DESCRIPTION
This is preparation work for [splitting `packit-service` image](https://github.com/packit-service/packit-service/issues/77).

Previously the `Dockerfile` was used to build an image for tests.
Now:
- there's a `Dockerfile.tests` for tests
- `Dockerfile` will be [used by docker hub](https://cloud.docker.com/u/usercont/repository/registry-1.docker.io/usercont/packit) to create an image which will be used as a base image for `packit-service worker` image. I've created a [stable](https://github.com/packit-service/packit/tree/stable) branch, which will be used by docker hub to create `:stable` packit image.