### PR TITLE
Don't show Copr projects on homepage

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -629,6 +629,10 @@ class PackitAPI:
                         "For more info check out https://packit.dev/"
                     ),
                     contact="user-cont-team@redhat.com",
+                    # don't show project on Copr homepage
+                    unlisted_on_hp=True,
+                    # delete project after the specified period of time
+                    delete_after_days=180,
                 )
             else:
                 raise PackitInvalidConfigException(

--- a/packit/api.py
+++ b/packit/api.py
@@ -628,7 +628,7 @@ class PackitAPI:
                         "Continuous builds initiated by packit service.\n"
                         "For more info check out https://packit.dev/"
                     ),
-                    contact="user-cont-team@redhat.com",
+                    contact="https://github.com/packit-service/packit/issues",
                     # don't show project on Copr homepage
                     unlisted_on_hp=True,
                     # delete project after the specified period of time


### PR DESCRIPTION
and delete projects after 6 months.

I'd let them hard-coded for now to keep things simple unless someone explicitly requests otherwise.