### PR TITLE
Allow slash in git_url

### DIFF
--- a/packit/utils.py
+++ b/packit/utils.py
@@ -179,6 +179,7 @@ def get_repo(url: str, directory: str = None) -> git.Repo:
 
 
 def get_namespace_and_repo_name(url: str) -> Tuple[str, str]:
+    url = url.strip("/")
     try:
         if url.endswith(".git"):
             url = url[:-4]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -30,6 +30,7 @@ from packit.utils import get_namespace_and_repo_name, is_str_url
     "url,namespace,repo_name",
     [
         ("https://github.com/org/name", "org", "name"),
+        ("https://github.com/org/name/", "org", "name"),
         ("https://github.com/org/name.git", "org", "name"),
         ("git@github.com:org/name", "org", "name"),
         ("git@github.com:org/name.git", "org", "name"),


### PR DESCRIPTION
Fixes following issue:
After running:
```
git clone https://github.com/containerbuildsystem/atomic-reactor/
cd atomic-reactor
packit generate
```
the packit.yml was weird
```
# See the documentation for more information:
# https://packit.dev/docs/configuration/

specfile_path: .spec

# add or remove files that should be synced
synced_files:
    - .spec
    - .packit.yaml

# name in upstream package repository/registry (e.g. in PyPI)
upstream_project_name:
# downstream (Fedora) RPM package name
downstream_package_name:
```