### PR TITLE
 [create_archive()] verify create-archive action output

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -32,4 +32,5 @@ jobs:
     targets:
     - fedora-29-x86_64
     - fedora-30-x86_64
+    - fedora-31-x86_64
     - fedora-rawhide-x86_64  # no compose for a week+, let's have ticks in our PRs

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -484,7 +484,17 @@ class Upstream(PackitRepositoryBase):
             outputs = self.get_output_from_action(
                 action=ActionName.create_archive, env=env
             )
-            return outputs[-1].strip() if outputs else None
+            if not outputs:
+                raise PackitException("No output from create-archive action.")
+            # one of the returned strings has to contain existing archive name
+            for archive_name in reversed(outputs):
+                if Path(archive_name.strip()).is_file():
+                    logger.info(f"Created archive: {archive_name.strip()}")
+                    return archive_name
+            else:
+                raise PackitException(
+                    "No existing file in create-archive action output."
+                )
 
         archive_extension = self.get_archive_extension(dir_name, version)
         if archive_extension not in COMMON_ARCHIVE_EXTENSIONS:


### PR DESCRIPTION
make sure that one of the returned strings contains name of an existing archive

This should have been in c7e320f