### PR TITLE
fix-spec,Source: default to Source0 and Source

### DIFF
--- a/tests/testsuite_basic/data/upstream_git/beer.spec
+++ b/tests/testsuite_basic/data/upstream_git/beer.spec
@@ -6,7 +6,7 @@ Release:        1%{?dist}
 Summary:        A tool to make you happy
 
 License:        Beerware
-Source0:        %{upstream_name}-%{version}.tar.gz
+Source:         %{upstream_name}-%{version}.tar.gz
 BuildArch:      noarch
 
 %description

--- a/tests/testsuite_basic/integration/test_upstream.py
+++ b/tests/testsuite_basic/integration/test_upstream.py
@@ -141,10 +141,10 @@ def test_set_spec_ver_empty_changelog(tmpdir):
     assert "%changelog" not in u.joinpath("beer.spec").read_text()
 
 
-def change_source0_ext(upstream, extension):
+def change_source_ext(upstream, extension):
     preamble = upstream.specfile.spec_content.section("%package")
     for i, line in enumerate(preamble):
-        if line.startswith("Source0"):
+        if line.startswith("Source"):
             source = line.split()[1]
             start = line.index(source)
             source = source.rstrip("".join(Path(source).suffixes)) + extension
@@ -157,7 +157,7 @@ def change_source0_ext(upstream, extension):
 )
 def test_create_archive(upstream_instance, extension):
     u, ups = upstream_instance
-    change_source0_ext(ups, extension)
+    change_source_ext(ups, extension)
 
     ups.create_archive()
 
@@ -174,7 +174,7 @@ def test_create_archive(upstream_instance, extension):
 
 def test_create_uncommon_archive(upstream_instance):
     u, ups = upstream_instance
-    change_source0_ext(ups, ".cpio")
+    change_source_ext(ups, ".cpio")
 
     with pytest.raises(PackitException):
         ups.create_archive()


### PR DESCRIPTION
Fixes #536

With this change, we default to Source0 and Source, which should improve UX for newcommers if they use Source in their spec files.

Everyone is still able to set their `Source\d` line their config.