### PR TITLE
convert `git remote get-url` into HTTPS url and use it

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -188,9 +188,6 @@ class PackitAPI:
             )
         current_up_branch = self.up.active_branch
         try:
-            # TODO: this is problematic, since we may overwrite stuff in the repo
-            #       but the thing is that we need to do it
-            #       I feel like the ideal thing to do would be to clone the repo and work in tmpdir
             upstream_tag = self.up.package_config.upstream_tag_template.format(
                 version=full_version
             )

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -371,7 +371,13 @@ class PackitRepositoryBase:
         self.specfile.set_version(this_version)
         self.specfile.save()
         rpmdev_bumpspec(self.absolute_specfile_path, comment=comment, version=version)
-        self.specfile._update_data()  # refresh the spec after we changed it
+        # refresh the spec after we changed it
+        if hasattr(self.specfile, "update"):
+            # new rebase-helper
+            self.specfile.update()
+        else:
+            # old rebase-helper
+            self.specfile._update_data()
 
     def is_dirty(self) -> bool:
         """ is the git repo dirty? """

--- a/packit/cli/types.py
+++ b/packit/cli/types.py
@@ -25,7 +25,8 @@ import os
 import click
 
 from packit.local_project import LocalProject
-from packit.utils import is_str_url
+from packit.utils import git_remote_url_to_https_url
+
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +66,7 @@ class LocalProjectParameter(click.ParamType):
                 local_project = LocalProject(
                     working_dir=value, ref=branch_name, remote=remote_name
                 )
-            elif is_str_url(value):
+            elif git_remote_url_to_https_url(value):
                 logger.info(f"Input is a URL to a git repo: {value}")
                 local_project = LocalProject(
                     git_url=value, ref=branch_name, remote=remote_name

--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -31,6 +31,7 @@ from github import GithubException
 from ogr.parsing import parse_git_repo
 from packit.api import PackitAPI
 from packit.config import get_local_package_config, Config
+from packit.constants import DIST_GIT_HOSTNAME_CANDIDATES
 from packit.exceptions import PackitException
 from packit.local_project import LocalProject
 
@@ -148,7 +149,7 @@ def get_packit_api(
 
         if package_config.dist_git_base_url and (
             remote_hostname in package_config.dist_git_base_url
-            or remote_hostname in "pkgs.fedoraproject.org"
+            or remote_hostname in DIST_GIT_HOSTNAME_CANDIDATES
         ):
             lp_downstream = local_project
             logger.info("Input directory is a downstream repository.")

--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -135,41 +135,28 @@ def get_packit_api(
     lp_upstream = None
     lp_downstream = None
 
-    upstream_compared = False
-
     for url in remote_urls:
         remote_hostname = get_hostname_or_none(url=url)
         if not remote_hostname:
             continue
 
         if upstream_hostname:
-            upstream_compared = True
             if remote_hostname == upstream_hostname:
                 lp_upstream = local_project
                 logger.info("Input directory is an upstream repository.")
                 break
 
-        if (
-            package_config.dist_git_base_url
-            and remote_hostname in package_config.dist_git_base_url
+        if package_config.dist_git_base_url and (
+            remote_hostname in package_config.dist_git_base_url
+            or remote_hostname in "pkgs.fedoraproject.org"
         ):
             lp_downstream = local_project
             logger.info("Input directory is a downstream repository.")
             break
     else:
-        if upstream_compared:
-            lp_downstream = local_project
-            logger.info(
-                "Input directory is a downstream repository "
-                "(upstream url does not match any git remote)."
-            )
-        else:
-            logger.warning(
-                "We cannot determine, "
-                "if the input is upstream or downstream. "
-                "Using upstream as a default."
-            )
-            lp_upstream = local_project
+        lp_upstream = local_project
+        # fallback, this is the past behavior
+        logger.info("Input directory is an upstream repository.")
 
     api = PackitAPI(
         config=config,

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -41,7 +41,15 @@ GH2FED_RELEASE_TOPIC = "org.fedoraproject.prod.github.release"
 
 DEFAULT_BODHI_NOTE = "New upstream release: {version}"
 
-PROD_DISTGIT_URL = "https://src.fedoraproject.org/"
+PROD_DISTGIT_HOSTNAME = "src.fedoraproject.org"
+PROD_DISTGIT_URL = f"https://{PROD_DISTGIT_HOSTNAME}/"
+ALTERNATIVE_PROD_DG_HOSTNAME = "pkgs.fedoraproject.org"
+DIST_GIT_HOSTNAME_CANDIDATES = (
+    PROD_DISTGIT_HOSTNAME,
+    ALTERNATIVE_PROD_DG_HOSTNAME,
+    "pkgs.stg.fedoraproject.org",
+    "src.stg.fedoraproject.org",
+)
 
 COPR2GITHUB_STATE = {
     "running": ("pending", "The RPM build was triggered."),

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -246,6 +246,10 @@ class DistGit(PackitRepositoryBase):
         with cwd(self.local_project.working_dir):
             self.specfile.download_remote_sources()
         archive = self.absolute_specfile_dir / self.upstream_archive_name
+        if not archive.exists():
+            raise PackitException(
+                "Upstream archive was not downloaded, something is wrong."
+            )
         logger.info(f"Downloaded archive: {archive}")
         return archive
 

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -75,7 +75,7 @@ class LocalProject:
 
         :param git_repo: git.Repo
         :param working_dir: str (working directory for the project)
-        :param ref: str (git ref (branch/tag/commit) if set, then checkouted)
+        :param ref: str (git ref (branch/tag/commit) if set, then checked out)
         :param git_project: ogr.GitProject (remote API for project)
         :param git_service: ogr.GitService (tokens for remote API)
         :param git_url: str (remote url used for cloning)
@@ -318,7 +318,6 @@ class LocalProject:
                 else:
                     # or use first one
                     self.git_url = next(self.git_repo.remotes[0].urls)
-
             else:
                 # Repo has no remotes
                 return False

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -30,7 +30,7 @@ import git
 from packaging import version
 from rebasehelper.exceptions import RebaseHelperError
 
-from packit.utils import is_a_git_ref, run_command
+from packit.utils import is_a_git_ref, run_command, git_remote_url_to_https_url
 
 try:
     from rebasehelper.plugins.plugin_manager import plugin_manager
@@ -74,8 +74,8 @@ class Upstream(PackitRepositoryBase):
             )
         if self._local_project.git_project is None:
             if not self.package_config.upstream_project_url:
-                raise PackitException(
-                    "Please, set 'upstream_project_url' in your config file."
+                self.package_config.upstream_project_url = git_remote_url_to_https_url(
+                    self._local_project.git_url
                 )
 
             self._local_project.git_project = self.config.get_project(

--- a/packit/utils.py
+++ b/packit/utils.py
@@ -304,6 +304,8 @@ def rpmdev_bumpspec(
     run_command(cmd)
 
 
+# TODO: merge this function into parse_git_repo in ogr
+# https://github.com/packit-service/packit/pull/555#discussion_r332871418
 def git_remote_url_to_https_url(inp: str) -> str:
     """
     turn provided git remote URL to https URL:

--- a/packit/utils.py
+++ b/packit/utils.py
@@ -23,6 +23,7 @@
 import json
 import logging
 import os
+import re
 import shlex
 import subprocess
 import tempfile
@@ -303,20 +304,34 @@ def rpmdev_bumpspec(
     run_command(cmd)
 
 
-def is_str_url(inp: str) -> bool:
-    """ is provided string a URL? """
+def git_remote_url_to_https_url(inp: str) -> str:
+    """
+    turn provided git remote URL to https URL:
+    returns empty string if the input can't be processed
+    """
     if not inp:
-        return False
+        return ""
     parsed = urlparse(inp)
-    if parsed.scheme:
-        logger.debug(f"Provided input {inp} is an url, scheme: {parsed.scheme}")
-        return True
-    elif inp.startswith("git@"):
-        url = urlparse(inp.replace(":", "/", 1).replace("git@", "git+ssh://", 1))
-        logger.debug(f"SSH style url {url} found.")
-        return True
+    if parsed.scheme and parsed.scheme in ["http", "https"]:
+        logger.debug(f"Provided input {inp} is an url.")
+        return inp
+    elif "@" in inp:
+        url_str = inp.replace("ssh://", "")
+        # now we can sub the colon (:) with slash (/)
+        url_str = url_str.replace(":", "/")
+        # and finally, get rid of the git@ junk
+        url_str = re.sub(r"\w+@", "https://", url_str)
+        # let's verify it's good
+        try:
+            urlparse(url_str)
+        except Exception:
+            logger.error(f"unable to process {inp}")
+            raise PackitException(f"Unable to process {inp}.")
+        else:
+            logger.debug(f"SSH style URL {inp} turned into HTTPS {url_str}")
+            return url_str
     logger.warning(f"{inp} is not an URL we recognize")
-    return False
+    return ""
 
 
 def get_packit_version() -> str:

--- a/tests/testsuite_basic/conftest.py
+++ b/tests/testsuite_basic/conftest.py
@@ -33,7 +33,7 @@ from rebasehelper.specfile import SpecFile
 
 from ogr.abstract import PullRequest, PRStatus
 from ogr.services.github import GithubService, GithubProject
-from ogr.services.pagure import PagureProject, PagureService
+from ogr.services.pagure import PagureProject, PagureService, PagureUser
 from packit.api import PackitAPI
 from packit.cli.utils import get_packit_api
 from packit.config import get_local_package_config
@@ -142,6 +142,7 @@ def mock_remote_functionality(distgit: Path, upstream: Path):
         get_git_urls=lambda: {"git": UPSTREAM_PROJECT_URL},
         fork_create=lambda: None,
     )
+    flexmock(PagureUser, get_username=lambda: "packito")
 
     mock_spec_download_remote_s(distgit)
 

--- a/tests/testsuite_basic/data/cockpit-ostree/packit.yaml
+++ b/tests/testsuite_basic/data/cockpit-ostree/packit.yaml
@@ -1,7 +1,7 @@
 specfile_path: cockpit-ostree.spec
 synced_files:
   - cockpit-ostree.spec
-upstream_project_name: cockpit-ostree
+upstream_package_name: cockpit-ostree
 downstream_package_name: cockpit-ostree
 upstream_project_url: "https://github.com/cockpit-project/cockpit-ostree"
 actions:

--- a/tests/testsuite_basic/data/dist_git/.packit.json
+++ b/tests/testsuite_basic/data/dist_git/.packit.json
@@ -3,7 +3,7 @@
   "synced_files": [
     "beer.spec"
   ],
-  "upstream_project_name": "beerware",
+  "upstream_package_name": "beerware",
   "downstream_package_name": "beer",
   "create_pr": false,
   "upstream_project_url": "../upstream_remote"

--- a/tests/testsuite_basic/data/empty_changelog/.packit.json
+++ b/tests/testsuite_basic/data/empty_changelog/.packit.json
@@ -3,7 +3,7 @@
   "synced_files": [
     "beer.spec"
   ],
-  "upstream_project_name": "beerware",
+  "upstream_package_name": "beerware",
   "downstream_package_name": "beer",
   "create_pr": false,
 }

--- a/tests/testsuite_basic/data/osbuild/.packit.yaml
+++ b/tests/testsuite_basic/data/osbuild/.packit.yaml
@@ -1,5 +1,5 @@
 specfile_path: osbuild.spec
-upstream_project_name: osbuild
+upstream_package_name: osbuild
 downstream_package_name: osbuild
 upstream_project_url: "https://github.com/osbuild/osbuild"
 current_version_command: ["python3", "setup.py", "--version"]

--- a/tests/testsuite_basic/data/upstream_git/.packit.json
+++ b/tests/testsuite_basic/data/upstream_git/.packit.json
@@ -3,8 +3,7 @@
   "synced_files": [
     "beer.spec"
   ],
-  "upstream_project_name": "beerware",
+  "upstream_package_name": "beerware",
   "downstream_package_name": "beer",
   "create_pr": false,
-  "upstream_project_url": "upstream_remote"
 }

--- a/tests/testsuite_basic/integration/test_build.py
+++ b/tests/testsuite_basic/integration/test_build.py
@@ -28,7 +28,7 @@ def test_basic_build(
     cwd_upstream_or_distgit, api_instance, mock_remote_functionality_upstream
 ):
     u, d, api = api_instance
-    flexmock(utils).should_receive("run_command").with_args(
+    flexmock(utils).should_receive("run_command_remote").with_args(
         cmd=["fedpkg", "build", "--scratch", "--nowait", "--target", "asdqwe"],
         cwd=api.dg.local_project.working_dir,
         error_message="Submission of build to koji failed.",

--- a/tests/testsuite_basic/integration/test_get_api.py
+++ b/tests/testsuite_basic/integration/test_get_api.py
@@ -59,7 +59,7 @@ def test_url_is_upstream():
         (
             [("origin", "https://github.com/packit-service/ogr.git")],
             flexmock(upstream_project_url="some-url", dist_git_base_url=None),
-            False,
+            True,
         ),
         (
             [("origin", "https://github.com/packit-service/ogr.git")],

--- a/tests/testsuite_basic/integration/test_update.py
+++ b/tests/testsuite_basic/integration/test_update.py
@@ -58,7 +58,6 @@ def test_basic_local_update(
     cwd_upstream, api_instance, mock_remote_functionality_upstream
 ):
     """ basic propose-update test: mock remote API, use local upstream and dist-git """
-
     u, d, api = api_instance
 
     api.sync_release("master", "0.1.0")
@@ -131,7 +130,7 @@ def test_local_update_with_specified_tag_template():
         {
             "specfile_path": "beer.spec",
             "synced_files": ["beer.spec"],
-            "upstream_project_name": "beerware",
+            "upstream_package_name": "beerware",
             "downstream_package_name": "beer",
             "upstream_tag_template": "v{version}",
             "create_pr": False,

--- a/tests/testsuite_basic/unit/test_config.py
+++ b/tests/testsuite_basic/unit/test_config.py
@@ -402,7 +402,7 @@ def test_package_config_parse_error(raw):
                 "jobs": [get_job_config_dict_full()],
                 "something": "stupid",
                 "upstream_project_url": "https://github.com/asd/qwe",
-                "upstream_project_name": "qwe",
+                "upstream_package_name": "qwe",
                 "dist_git_base_url": "https://something.wicked",
                 "downstream_package_name": "package",
             },

--- a/tests/testsuite_basic/unit/test_utils.py
+++ b/tests/testsuite_basic/unit/test_utils.py
@@ -27,7 +27,7 @@ from flexmock import flexmock
 from packit.exceptions import PackitException
 from packit.utils import (
     get_namespace_and_repo_name,
-    is_str_url,
+    git_remote_url_to_https_url,
     run_command,
     get_packit_version,
 )
@@ -59,15 +59,21 @@ def test_get_ns_repo_exc():
 @pytest.mark.parametrize(
     "inp,ok",
     [
-        ("/", False),
-        (None, False),
-        ("https://github.com/packit-service/packit", True),
-        ("git@github.com:packit-service/ogr", True),
-        ("ssh://ttomecek@pkgs.fedoraproject.org/rpms/alot.git", True),
+        ("/", ""),
+        (None, ""),
+        (
+            "https://github.com/packit-service/packit",
+            "https://github.com/packit-service/packit",
+        ),
+        ("git@github.com:packit-service/ogr", "https://github.com/packit-service/ogr"),
+        (
+            "ssh://ttomecek@pkgs.fedoraproject.org/rpms/alot.git",
+            "https://pkgs.fedoraproject.org/rpms/alot.git",
+        ),
     ],
 )
-def test_is_str_url(inp, ok):
-    assert is_str_url(inp) == ok
+def test_remote_to_https(inp, ok):
+    assert git_remote_url_to_https_url(inp) == ok
 
 
 def test_run_command_w_env():

--- a/tests/testsuite_recording/integration/test_api.py
+++ b/tests/testsuite_recording/integration/test_api.py
@@ -87,11 +87,12 @@ class ProposeUpdate(PackitUnittestOgr):
         """
         self.assertRaises(RebaseHelperError, self.check_version_increase)
 
-    @unittest.skipUnless(
-        hasattr(rebasehelper, "VERSION")
-        and int(rebasehelper.VERSION.split(".")[1]) >= 19,
-        "New version of rebasehelper works without raised exception",
-    )
+    # @unittest.skipUnless(
+    #     hasattr(rebasehelper, "VERSION")
+    #     and int(rebasehelper.VERSION.split(".")[1]) >= 19,
+    #     "New version of rebasehelper works without raised exception",
+    # )
+    @unittest.skip(reason="https://github.com/packit-service/packit/issues/558")
     def test_version_change_new_rebaseheler(self):
         """
         check if it not raises exception, because sources are not uploaded in distgit

--- a/tests/testsuite_recording/integration/testbase.py
+++ b/tests/testsuite_recording/integration/testbase.py
@@ -1,18 +1,17 @@
 import inspect
 import os
-import unittest
 import shutil
+import unittest
 from subprocess import check_output, CalledProcessError
+
+from requre.helpers.tempfile import TempFile
+from requre.storage import PersistentObjectStorage
 
 import packit.distgit
 import packit.upstream
-from ogr import GithubService, PagureService
-
-from requre.storage import PersistentObjectStorage
-from requre.helpers.tempfile import TempFile
-
 from packit.config import Config
 from packit.config import get_package_config_from_repo
+from packit.exceptions import PackitException
 from packit.local_project import LocalProject
 
 DATA_DIR = "test_data"
@@ -28,14 +27,10 @@ class PackitUnittestOgr(unittest.TestCase):
 
     @staticmethod
     def get_test_config():
-        conf = Config()
-        pagure_user_token = os.environ.get("PAGURE_TOKEN", "test")
-        github_token = os.environ.get("GITHUB_TOKEN", "test")
-        conf.services = {
-            PagureService(token=pagure_user_token),
-            GithubService(token=github_token),
-        }
-
+        try:
+            conf = Config.get_user_config()
+        except PackitException:
+            conf = Config()
         conf.dry_run = True
         return conf
 


### PR DESCRIPTION
this way, people won't need to specify upstream_project_url

Fixes #553