### PR TITLE
Fixed: 'Event loop is closed' while calling status from API more than once

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -556,7 +556,7 @@ class PackitAPI:
             return []
 
     @staticmethod
-    async def status_main(status: Status) -> List:
+    async def status_main(status: Status) -> Tuple:
         """
         Schedule repository data retrieval calls concurrently.
         :param status: status of the package
@@ -573,7 +573,7 @@ class PackitAPI:
 
     def status(self) -> None:
         status = Status(self.config, self.package_config, self.up, self.dg)
-        if sys.version_info >= (3,7,0):
+        if sys.version_info >= (3, 7, 0):
             res = asyncio.run(self.status_main(status))
         else:
             # backward compatibility for Python 3.6


### PR DESCRIPTION
Related Issue: https://github.com/packit-service/packit/issues/570

## Description:
In the first call of the `status` API, the global event loop was fetched and later it was closed. The second attempt to get an event loop failed as that had been closed already which resulted in the error.

I considered two ways to fix that:

**Option 1**: Set a new event loop using `asyncio.set_event_loop(asyncio.new_event_loop())` and then use `asyncio.get_event_loop` again.

**Option 2**: Use `asyncio.run()` which essentially [does the same thing as option 1](https://docs.python.org/3/library/asyncio-task.html#asyncio.run), but it's already available in the library for consumption.

_I propose Option 2, as `run` is a high level call providing the exact functionality thereby saving us the trouble of managing event loops directly in our code. Also, because of the fact that it makes the code neater and more maintainable._

cc: @dhodovsk @eliskasl @lachmanfrantisek 
