### PR TITLE
Split longer action output for create-archive

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -455,7 +455,10 @@ class Upstream(PackitRepositoryBase):
             for output in reversed(outputs):
                 for archive_name in reversed(output.splitlines()):
                     try:
-                        if Path(archive_name.strip()).is_file():
+                        archive_path = Path(
+                            self._local_project.working_dir, archive_name.strip()
+                        )
+                        if archive_path.is_file():
                             logger.info(f"Created archive: {archive_name.strip()}")
                             return archive_name
                     except OSError as ex:


### PR DESCRIPTION
Fix for situations when actions produce long output.
For example as found in cockpit-ostree:
```
[dhodovsk@shiny cockpit-ostree]$ packit srpm
Packit 0.7.2.dev6+g6b8220c is being used.
Input is a directory: /tmp/cockpit-ostree
WARNING  'upstream_project_name' configuration key was renamed to 'upstream_package_name', please update your configuration file
Input directory is an upstream repository.
Using user-defined script for ActionName.post_upstream_clone: ['make cockpit-ostree.spec']
Using user-defined script for ActionName.create_archive: ['make', 'dist-gzip']
STDERR: npm WARN deprecated angular-bootstrap-npm@0.13.4: angular bootstrap is not being published by original team
npm WARN deprecated nomnom@1.8.1: Package no longer supported. Contact support@npmjs.com for more info.
npm WARN deprecated natives@1.1.6: This module relies on Node.js's internals and will break at some point. Do not use it, and update to graceful-fs@4.x.
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.9 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.9: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
ERROR    [Errno 36] File name too long: 'npm install\n\n> core-js@2.6.10 postinstall /tmp/cockpit-ostree/node_modules/core-js\n> node postinstall || echo "ignore"\n\nadded 922 packages from 485 contributors and audited 8111 packages in 11.4s\nfound 4 vulnerabilities (1 moderate, 2 high, 1 critical)\n  run `npm audit fix` to fix them, or `npm audit` for details\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.pa.js.js.tmp po/pa.po\nmv dist/po.pa.js.js.tmp dist/po.pa.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.ja.js.js.tmp po/ja.po\nmv dist/po.ja.js.js.tmp dist/po.ja.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.de.js.js.tmp po/de.po\nmv dist/po.de.js.js.tmp dist/po.de.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.tr.js.js.tmp po/tr.po\nmv dist/po.tr.js.js.tmp dist/po.tr.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.da.js.js.tmp po/da.po\nmv dist/po.da.js.js.tmp dist/po.da.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.ca.js.js.tmp po/ca.po\nmv dist/po.ca.js.js.tmp dist/po.ca.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.pl.js.js.tmp po/pl.po\nmv dist/po.pl.js.js.tmp dist/po.pl.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.my.js.js.tmp po/my.po\nmv dist/po.my.js.js.tmp dist/po.my.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.fi.js.js.tmp po/fi.po\nmv dist/po.fi.js.js.tmp dist/po.fi.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.es.js.js.tmp po/es.po\nmv dist/po.es.js.js.tmp dist/po.es.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.hr.js.js.tmp po/hr.po\nmv dist/po.hr.js.js.tmp dist/po.hr.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.pt.js.js.tmp po/pt.po\nmv dist/po.pt.js.js.tmp dist/po.pt.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.eu.js.js.tmp po/eu.po\nmv dist/po.eu.js.js.tmp dist/po.eu.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.fr.js.js.tmp po/fr.po\nmv dist/po.fr.js.js.tmp dist/po.fr.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.ko.js.js.tmp po/ko.po\nmv dist/po.ko.js.js.tmp dist/po.ko.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.cs.js.js.tmp po/cs.po\nmv dist/po.cs.js.js.tmp dist/po.cs.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.pt_BR.js.js.tmp po/pt_BR.po\nmv dist/po.pt_BR.js.js.tmp dist/po.pt_BR.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.uk.js.js.tmp po/uk.po\nmv dist/po.uk.js.js.tmp dist/po.uk.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.nl.js.js.tmp po/nl.po\nmv dist/po.nl.js.js.tmp dist/po.nl.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.zh_CN.js.js.tmp po/zh_CN.po\nmv dist/po.zh_CN.js.js.tmp dist/po.zh_CN.js\nmkdir -p dist/\npo/po2json -m po/po.empty.js -o dist/po.hu.js.js.tmp po/hu.po\nmv dist/po.hu.js.js.tmp dist/po.hu.js\nNODE_ENV=production npm run build\n\n> cockpit-ostree@0.1.0 build /tmp/cockpit-ostree\n> webpack\n\nHash: aaa4727de2ed95e95129\nVersion: webpack 4.41.2\nTime: 9612ms\nBuilt at: 10/24/2019 11:06:55 AM\n            Asset       Size  Chunks                   Chunk Names\n       index.html   19.1 KiB          [emitted]        \n    manifest.json  225 bytes          [emitted]        \n       ostree.css   18.8 KiB       0  [emitted]        ostree\n   ostree.css.map   87 bytes       0  [emitted] [dev]  ostree\n ostree.min.js.gz    146 KiB          [emitted]        \nostree.min.js.map   2.42 MiB       0  [emitted] [dev]  ostree\nEntrypoint ostree = ostree.min.js ostree.css ostree.min.js.map ostree.css.map\n  [1] external "cockpit" 42 bytes {0} [built]\n[131] multi ./src/app.js ./src/ostree.less 40 bytes {0} [built]\n[132] (webpack)/buildin/module.js 497 bytes {0} [built]\n[133] ./node_modules/moment/locale sync ^\\.\\/.*$ 3 KiB {0} [optional] [built]\n[138] ./src/app.js + 4 modules 53.1 KiB {0} [built]\n      | ./src/app.js 11.9 KiB [built]\n      | ./src/angular-dialog.js 9.84 KiB [built]\n      | ./src/client.js 18.2 KiB [built]\n      | ./src/remotes.js 9.95 KiB [built]\n      | ./src/utils.js 3.25 KiB [built]\n[139] ./src/ostree.less 41 bytes [built]\n    + 135 hidden modules\nChild extract-text-webpack-plugin node_modules/extract-text-webpack-plugin/dist node_modules/css-loader/dist/cjs.js!node_modules/less-loader/dist/cjs.js!src/ostree.less:\n    Entrypoint undefined = extract-text-webpack-plugin-output-filename\n    [0] ./node_modules/css-loader/dist/cjs.js!./node_modules/less-loader/dist/cjs.js!./src/ostree.less 19.8 KiB {0} [built]\n        + 1 hidden module\nmv node_modules node_modules.release\nmkdir -p node_modules/po2json\ntouch -r package.json node_modules/po2json\ntouch dist/*\ntar czf cockpit-ostree-179.7.ge4ad2d9.tar.gz --transform \'s,^,cockpit-ostree/,\' \\\n\t--exclude cockpit-ostree.spec.in \\\n\t$(git ls-files) cockpit-ostree.spec dist/ node_modules\nrm -rf node_modules\nmv node_modules.release node_modules'
Unexpected exception occurred,
please fill an issue here:
https://github.com/packit-service/packit/issues

```

Also fixes: https://github.com/packit-service/packit-service/issues/186 (tried on stage - https://github.com/packit-service/hello-world/pull/28)