### PR TITLE
srcgit: patches can have undecodable chars

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -248,7 +248,10 @@ class Upstream(PackitRepositoryBase):
                 )
             ]
             diff = run_command(
-                cmd=git_diff_cmd, cwd=self.local_project.working_dir, output=True
+                cmd=git_diff_cmd,
+                cwd=self.local_project.working_dir,
+                output=True,
+                decode=False,
             )
 
             if not diff:
@@ -264,7 +267,7 @@ class Upstream(PackitRepositoryBase):
             patch_msg = f"{commit.summary}\nAuthor: {commit.author.name} <{commit.author.email}>"
 
             logger.debug(f"Saving patch: {patch_name}\n{patch_msg}")
-            with open(patch_path, mode="w") as patch_file:
+            with open(patch_path, mode="wb") as patch_file:
                 patch_file.write(diff)
             patch_list.append((patch_name, patch_msg))
 

--- a/tests/unit/test_unicodez.py
+++ b/tests/unit/test_unicodez.py
@@ -1,0 +1,24 @@
+"""
+the worst file in the universe
+"""
+from pathlib import Path
+
+import pytest
+
+from packit.utils import run_command
+
+
+def test_run_cmd_unicode(tmpdir):
+    # don't ask me what this is, I took it directly from systemd's test suite
+    # that's what packit was UnicodeDecodeError-ing on
+    cancer = (
+        b"\x06\xd0\xf1\t\x01\xa1\x01\t "
+        b"\x15\x00&\xff\x00u\x08\x95@\x81\x02\t!\x15\x00&\xff\x00u\x08\x95@\x91\x02\xc0"
+    )
+    t = Path(tmpdir).joinpath("the-cancer")
+    t.write_bytes(cancer)
+    command = ["cat", str(t)]
+    assert cancer == run_command(command, decode=False, output=True)
+
+    with pytest.raises(UnicodeDecodeError):
+        run_command(command, decode=True, output=True)


### PR DESCRIPTION
Fixes problem from https://github.com/packit-service/systemd-rhel8-flock/pull/9#issuecomment-550183552

Locally with `packit srpm`:
```
13:01:53.471 utils.py          DEBUG  b'Wrote: /home/tt/t/systemd-rhel8-flock/systemd-243-2.gc3bfb0bb.fc30.src.rpm'
13:01:53.475 upstream.py       DEBUG  Wrote: /home/tt/t/systemd-rhel8-flock/systemd-243-2.gc3bfb0bb.fc30.src.rpm
SRPM is /home/tt/t/systemd-rhel8-flock/systemd-243-2.gc3bfb0bb.fc30.src.rpm
SRPM: /home/tt/t/systemd-rhel8-flock/systemd-243-2.gc3bfb0bb.fc30.src.rpm
```