### PR TITLE
Aliases

### DIFF
--- a/packit/cli/build.py
+++ b/packit/cli/build.py
@@ -28,6 +28,7 @@ import click
 from packit.cli.types import LocalProjectParameter
 from packit.cli.utils import cover_packit_exception, get_packit_api
 from packit.config import pass_config, get_context_settings
+from packit.config.aliases import get_branches
 
 logger = logging.getLogger(__file__)
 
@@ -35,7 +36,8 @@ logger = logging.getLogger(__file__)
 @click.command("build", context_settings=get_context_settings())
 @click.option(
     "--dist-git-branch",
-    help="Target branch in dist-git to release into.",
+    help="Comma separated list of target branches in dist-git to release into. "
+    "(defaults to 'master')",
     default="master",
 )
 @click.option(
@@ -67,4 +69,15 @@ def build(
     api = get_packit_api(
         config=config, dist_git_path=dist_git_path, local_project=path_or_url
     )
-    api.build(dist_git_branch, scratch=scratch, nowait=nowait, koji_target=koji_target)
+
+    branches_to_build = get_branches(*dist_git_branch.split(","), default="master")
+
+    click.echo(f"Building for the following branches: {', '.join(branches_to_build)}")
+
+    for branch in branches_to_build:
+        api.build(
+            dist_git_branch=branch,
+            scratch=scratch,
+            nowait=nowait,
+            koji_target=koji_target,
+        )

--- a/packit/cli/build.py
+++ b/packit/cli/build.py
@@ -71,7 +71,6 @@ def build(
     )
 
     branches_to_build = get_branches(*dist_git_branch.split(","), default="master")
-
     click.echo(f"Building for the following branches: {', '.join(branches_to_build)}")
 
     for branch in branches_to_build:

--- a/packit/cli/copr_build.py
+++ b/packit/cli/copr_build.py
@@ -28,6 +28,7 @@ import click
 from packit.cli.types import LocalProjectParameter
 from packit.cli.utils import cover_packit_exception, get_packit_api
 from packit.config import pass_config, get_context_settings
+from packit.config.aliases import get_build_targets
 
 
 @click.command("copr-build", context_settings=get_context_settings())
@@ -68,9 +69,14 @@ def copr_build(
     """
     api = get_packit_api(config=config, local_project=path_or_url)
     default_project_name = f"packit-cli-{path_or_url.repo_name}-{path_or_url.ref}"
+
+    targets_to_build = get_build_targets(
+        *targets.split(","), default="fedora-rawhide-x86_64"
+    )
+
     build_id, repo_url = api.run_copr_build(
         project=project or default_project_name,
-        chroots=targets.split(","),
+        chroots=list(targets_to_build),
         owner=owner,
         description=description,
         instructions=instructions,

--- a/packit/cli/sync_from_downstream.py
+++ b/packit/cli/sync_from_downstream.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__file__)
 @click.command("sync-from-downstream", context_settings=get_context_settings())
 @click.option(
     "--dist-git-branch",
-    help="Comma separated list of target branches in dist-git to release into. "
+    help="Comma separated list of target branches in dist-git to sync from. "
     "(defaults to 'master')",
     default="master",
 )

--- a/packit/cli/sync_from_downstream.py
+++ b/packit/cli/sync_from_downstream.py
@@ -32,6 +32,7 @@ import click
 from packit.cli.types import LocalProjectParameter
 from packit.cli.utils import cover_packit_exception, get_packit_api
 from packit.config import pass_config, get_context_settings
+from packit.config.aliases import get_branches
 
 logger = logging.getLogger(__file__)
 
@@ -39,7 +40,8 @@ logger = logging.getLogger(__file__)
 @click.command("sync-from-downstream", context_settings=get_context_settings())
 @click.option(
     "--dist-git-branch",
-    help="Source branch in dist-git to sync from.",
+    help="Comma separated list of target branches in dist-git to release into. "
+    "(defaults to 'master')",
     default="master",
 )
 @click.option(
@@ -98,12 +100,17 @@ def sync_from_downstream(
     it defaults to the current working directory
     """
     api = get_packit_api(config=config, local_project=path_or_url)
-    api.sync_from_downstream(
-        dist_git_branch,
-        upstream_branch,
-        no_pr=no_pr,
-        fork=fork,
-        remote_name=remote,
-        exclude_files=exclude,
-        force=force,
-    )
+
+    branches_to_sync = get_branches(*dist_git_branch.split(","), default="master")
+    click.echo(f"Syncing from the following branches: {', '.join(branches_to_sync)}")
+
+    for branch in branches_to_sync:
+        api.sync_from_downstream(
+            dist_git_branch=branch,
+            upstream_branch=upstream_branch,
+            no_pr=no_pr,
+            fork=fork,
+            remote_name=remote,
+            exclude_files=exclude,
+            force=force,
+        )

--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -1,0 +1,102 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from typing import Dict, List, Set
+
+from packit.exceptions import PackitException
+
+ALIASES: Dict[str, List[str]] = {
+    "fedora-development": ["fedora-rawhide", "fedora-32"],
+    "fedora-stable": ["fedora-30", "fedora-31"],
+}
+ARCHITECTURE_LIST: List[str] = [
+    "aarch64",
+    "armhfp",
+    "i386",
+    "ppc64le",
+    "s390x",
+    "x86_64",
+]
+DEFAULT_VERSION = "fedora-stable"
+
+
+def get_versions(*name: str, default=DEFAULT_VERSION) -> Set[str]:
+    names = list(name) or [default]
+    versions: Set[str] = set()
+    for one_name in names:
+        versions.update(ALIASES.get(one_name, [one_name]))
+    return versions
+
+
+def get_build_targets(*name: str, default=DEFAULT_VERSION) -> Set[str]:
+    names = list(name) or [default]
+    possible_sys_and_versions: Set[str] = set([])
+    for one_name in names:
+        name_split = one_name.rsplit("-", maxsplit=2)
+        if len(name_split) < 2:
+            raise PackitException(f"Cannot get build target from '{one_name}'.")
+
+        if len(name_split) == 2:
+            sys_name, version = name_split
+            architecture = "x86_64"  # use the x86_64 as a default
+        else:
+            sys_name, version, architecture = name_split
+            if architecture not in ARCHITECTURE_LIST:
+                # wrong parsing => we don't know the architecture
+                sys_name, version, architecture = (
+                    f"{sys_name}-{version}",
+                    architecture,
+                    "x86_64",
+                )
+
+        possible_sys_and_versions.update(
+            {
+                f"{sys_and_version}-{architecture}"
+                for sys_and_version in get_versions(f"{sys_name}-{version}")
+            }
+        )
+    return possible_sys_and_versions
+
+
+def get_branches(*name: str, default=DEFAULT_VERSION) -> Set[str]:
+    names = list(name) or [default]
+    branches = set()
+    for sys_and_version in get_versions(*names):
+        if "rawhide" in sys_and_version:
+            branches.add("master")
+        elif sys_and_version.startswith("fedora"):
+            sys, version = sys_and_version.rsplit("-", maxsplit=1)
+            branches.add(f"f{version}")
+        elif sys_and_version.startswith("epel"):
+            split = sys_and_version.rsplit("-", maxsplit=1)
+            if len(split) < 2:
+                branches.add(sys_and_version)
+                continue
+            sys, version = sys_and_version.rsplit("-", maxsplit=1)
+            if version.isnumeric() and int(version) <= 6:
+                branches.add(f"el{version}")
+            else:
+                branches.add(f"epel{version}")
+        else:
+            # We don't know, let's leave the original name.
+            branches.add(sys_and_version)
+
+    return branches

--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -26,6 +26,7 @@ from packit.exceptions import PackitException
 ALIASES: Dict[str, List[str]] = {
     "fedora-development": ["fedora-rawhide", "fedora-32"],
     "fedora-stable": ["fedora-30", "fedora-31"],
+    "fedora-all": ["fedora-rawhide", "fedora-32", "fedora-30", "fedora-31"],
 }
 ARCHITECTURE_LIST: List[str] = [
     "aarch64",

--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -53,9 +53,12 @@ def get_build_targets(*name: str, default=DEFAULT_VERSION) -> Set[str]:
     for one_name in names:
         name_split = one_name.rsplit("-", maxsplit=2)
         if len(name_split) < 2:
-            raise PackitException(f"Cannot get build target from '{one_name}'.")
+            if "rawhide" in one_name:
+                sys_name, version, architecture = "fedora", "rawhide", "x86_64"
+            else:
+                raise PackitException(f"Cannot get build target from '{one_name}'.")
 
-        if len(name_split) == 2:
+        elif len(name_split) == 2:
             sys_name, version = name_split
             architecture = "x86_64"  # use the x86_64 as a default
         else:

--- a/tests/unit/test_config_aliases.py
+++ b/tests/unit/test_config_aliases.py
@@ -1,0 +1,99 @@
+import pytest
+
+from packit.config.aliases import get_versions, get_build_targets, get_branches
+
+
+@pytest.mark.parametrize(
+    "name,versions",
+    [
+        ("fedora-29", {"fedora-29"}),
+        ("epel-8", {"epel-8"}),
+        ("fedora-rawhide", {"fedora-rawhide"}),
+        ("openmandriva-rolling", {"openmandriva-rolling"}),
+        ("opensuse-leap-15.0", {"opensuse-leap-15.0"}),
+        ("fedora-stable", {"fedora-30", "fedora-31"}),
+        ("fedora-development", {"fedora-rawhide", "fedora-32"}),
+        ("centos-stream", {"centos-stream"}),
+    ],
+)
+def test_get_versions(name, versions):
+    assert get_versions(name) == versions
+
+
+@pytest.mark.parametrize(
+    "names,versions",
+    [
+        (["fedora-29", "fedora-stable"], {"fedora-29", "fedora-30", "fedora-31"}),
+        (["fedora-30", "fedora-stable"], {"fedora-30", "fedora-31"}),
+    ],
+)
+def test_get_versions_from_multiple_values(names, versions):
+    assert get_versions(*names) == versions
+
+
+@pytest.mark.parametrize(
+    "name,targets",
+    [
+        ("fedora-29", {"fedora-29-x86_64"}),
+        ("epel-8", {"epel-8-x86_64"}),
+        ("fedora-rawhide", {"fedora-rawhide-x86_64"}),
+        ("openmandriva-rolling", {"openmandriva-rolling-x86_64"}),
+        ("opensuse-leap-15.0", {"opensuse-leap-15.0-x86_64"}),
+        ("centos-stream", {"centos-stream-x86_64"}),
+        ("centos-stream-x86_64", {"centos-stream-x86_64"}),
+        ("fedora-stable", {"fedora-30-x86_64", "fedora-31-x86_64"}),
+        ("fedora-development", {"fedora-rawhide-x86_64", "fedora-32-x86_64"}),
+        ("fedora-29-x86_64", {"fedora-29-x86_64"}),
+        ("fedora-29-aarch64", {"fedora-29-aarch64"}),
+        ("fedora-29-i386", {"fedora-29-i386"}),
+        ("fedora-stable-aarch64", {"fedora-30-aarch64", "fedora-31-aarch64"}),
+        ("fedora-development-aarch64", {"fedora-rawhide-aarch64", "fedora-32-aarch64"}),
+    ],
+)
+def test_get_build_targets(name, targets):
+    assert get_build_targets(name) == targets
+
+
+@pytest.mark.parametrize(
+    "names,versions",
+    [
+        (
+            ["fedora-29", "fedora-stable"],
+            {"fedora-29-x86_64", "fedora-30-x86_64", "fedora-31-x86_64"},
+        ),
+        (["fedora-30", "fedora-stable"], {"fedora-30-x86_64", "fedora-31-x86_64"}),
+    ],
+)
+def test_get_build_targets_from_multiple_values(names, versions):
+    assert get_build_targets(*names) == versions
+
+
+@pytest.mark.parametrize(
+    "name,branches",
+    [
+        ("fedora-29", {"f29"}),
+        ("fedora-rawhide", {"master"}),
+        ("rawhide", {"master"}),
+        ("master", {"master"}),
+        ("f30", {"f30"}),
+        ("fedora-development", {"master", "f32"}),
+        ("fedora-stable", {"f30", "f31"}),
+        ("epel-7", {"epel7"}),
+        ("epel7", {"epel7"}),
+        ("el6", {"el6"}),
+        ("epel-6", {"el6"}),
+    ],
+)
+def test_get_branches(name, branches):
+    assert get_branches(name) == branches
+
+
+@pytest.mark.parametrize(
+    "names,versions",
+    [
+        (["fedora-29", "fedora-stable"], {"f29", "f30", "f31"}),
+        (["fedora-30", "fedora-stable"], {"f30", "f31"}),
+    ],
+)
+def test_get_branches_from_multiple_values(names, versions):
+    assert get_branches(*names) == versions

--- a/tests/unit/test_config_aliases.py
+++ b/tests/unit/test_config_aliases.py
@@ -13,6 +13,7 @@ from packit.config.aliases import get_versions, get_build_targets, get_branches
         ("opensuse-leap-15.0", {"opensuse-leap-15.0"}),
         ("fedora-stable", {"fedora-30", "fedora-31"}),
         ("fedora-development", {"fedora-rawhide", "fedora-32"}),
+        ("fedora-all", {"fedora-rawhide", "fedora-30", "fedora-31", "fedora-32"}),
         ("centos-stream", {"centos-stream"}),
     ],
 )
@@ -48,6 +49,15 @@ def test_get_versions_from_multiple_values(names, versions):
         ("fedora-29-i386", {"fedora-29-i386"}),
         ("fedora-stable-aarch64", {"fedora-30-aarch64", "fedora-31-aarch64"}),
         ("fedora-development-aarch64", {"fedora-rawhide-aarch64", "fedora-32-aarch64"}),
+        (
+            "fedora-all",
+            {
+                "fedora-rawhide-x86_64",
+                "fedora-30-x86_64",
+                "fedora-31-x86_64",
+                "fedora-32-x86_64",
+            },
+        ),
     ],
 )
 def test_get_build_targets(name, targets):
@@ -82,6 +92,7 @@ def test_get_build_targets_from_multiple_values(names, versions):
         ("epel7", {"epel7"}),
         ("el6", {"el6"}),
         ("epel-6", {"el6"}),
+        ("fedora-all", {"master", "f30", "f31", "f32"}),
     ],
 )
 def test_get_branches(name, branches):


### PR DESCRIPTION
Fixes (partially) #540
- Only the `packit` part. Service needs to be updated as well.


- Aliases:
```
    "fedora-development": ["fedora-rawhide", "fedora-32"]
    "fedora-stable": ["fedora-30", "fedora-31"]
    "fedora-all": ["fedora-rawhide", "fedora-32", "fedora-30", "fedora-31"]
```
- Add alias mapping to version, build-target and branch.
- CLI command support:
    - `packit propose-update`
    - `packit sync-from-downstream`
    - `packit copr-build`
    - `packit build`
    - `packit create-update`
- The CLI should work at least as before. I'll create the integration tests for the multiple branches in/after #612 
