### PR TITLE
Catch the fedpkg build failure

### DIFF
--- a/packit/exceptions.py
+++ b/packit/exceptions.py
@@ -28,8 +28,10 @@ class PackitException(Exception):
 class PackitCommandFailedError(PackitException):
     """ A command failed """
 
-    def __init__(self, output):
-        self.output = output
+    def __init__(self, *args, stdout_output=None, stderr_output=None):
+        super().__init__(*args)
+        self.stdout_output = stdout_output
+        self.stderr_output = stderr_output
 
 
 class PackitConfigException(PackitException):

--- a/packit/utils.py
+++ b/packit/utils.py
@@ -26,6 +26,7 @@ import os
 import re
 import shlex
 import subprocess
+import sys
 import tempfile
 import threading
 from contextlib import contextmanager
@@ -34,10 +35,9 @@ from typing import Tuple, Any, Optional, Dict, Union, List
 from urllib.parse import urlparse
 
 import git
-import sys
 from pkg_resources import get_distribution, DistributionNotFound
 
-from packit.exceptions import PackitException
+from packit.exceptions import PackitException, PackitCommandFailedError
 
 logger = logging.getLogger(__name__)
 
@@ -138,7 +138,11 @@ def run_command(
         logger.error("Command %s failed", shell.args)
         logger.error("%s", error_message)
         if fail:
-            raise PackitException(f"Command {shell.args!r} failed: {error_message}")
+            raise PackitCommandFailedError(
+                f"Command {shell.args!r} failed: {error_message}",
+                stdout_output=stdout.get_output(),
+                stderr_output=stderr.get_output(),
+            )
         success = False
     else:
         success = True


### PR DESCRIPTION
- Catch the failed fedpkg-build.
- Nicer build output.

```
# packit build --scratch https://github.com/packit-service/ogr --dist-git-branch=fedora-all
Packit 0.7.2.dev104+g446a9f7.d20191210 is being used.
Input is a URL to a git repo: https://github.com/packit-service/ogr
Input directory is an upstream repository.
Building for the following branches: master, f30, f31
Using 'master' dist-git branch
won't be doing kinit, no credentials provided
won't be doing kinit, no credentials provided
b"Could not execute build: watch_tasks() got an unexpected keyword argument 'ki_handler'"
ERROR    Command ['fedpkg', 'build', '--scratch'] failed
ERROR    Submission of build to koji failed.
Build for branch 'master' failed. 
>>> Building python-ogr-0.9.0-1.fc32 for rawhide
>>> Created task: 39474710
>>> Task info: https://koji.fedoraproject.org/koji/taskinfo?taskID=39474710
!!! Could not execute build: watch_tasks() got an unexpected keyword argument 'ki_handler'

Using 'f30' dist-git branch
won't be doing kinit, no credentials provided
b"Could not execute build: watch_tasks() got an unexpected keyword argument 'ki_handler'"
ERROR    Command ['fedpkg', 'build', '--scratch'] failed
ERROR    Submission of build to koji failed.
Build for branch 'f30' failed. 
>>> Building python-ogr-0.9.0-1.fc30 for f30-candidate
>>> Created task: 39474711
>>> Task info: https://koji.fedoraproject.org/koji/taskinfo?taskID=39474711
!!! Could not execute build: watch_tasks() got an unexpected keyword argument 'ki_handler'

Using 'f31' dist-git branch
won't be doing kinit, no credentials provided
b"Could not execute build: watch_tasks() got an unexpected keyword argument 'ki_handler'"
ERROR    Command ['fedpkg', 'build', '--scratch'] failed
ERROR    Submission of build to koji failed.
Build for branch 'f31' failed. 
>>> Building python-ogr-0.9.0-1.fc31 for f31-candidate
>>> Created task: 39474714
>>> Task info: https://koji.fedoraproject.org/koji/taskinfo?taskID=39474714
!!! Could not execute build: watch_tasks() got an unexpected keyword argument 'ki_handler'

```