### PR TITLE
new config opt: exclude paths from patching

### DIFF
--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -63,11 +63,13 @@ class PackageConfig:
         create_pr: bool = True,
         spec_source_id: str = "Source0",
         upstream_tag_template: str = "{version}",
+        patch_generation_ignore_paths: List[str] = None,
         **kwargs,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
         self.synced_files: SyncFilesConfig = synced_files or SyncFilesConfig([])
+        self.patch_generation_ignore_paths = patch_generation_ignore_paths or []
         self.jobs: List[JobConfig] = jobs or []
         self.dist_git_namespace: str = dist_git_namespace or "rpms"
         self.upstream_project_url: Optional[str] = upstream_project_url

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -171,6 +171,7 @@ class PackageConfigSchema(Schema):
     jobs = fields.Nested(JobConfigSchema, many=True, default=default_jobs)
     actions = ActionField(default={})
     create_pr = fields.Bool(default=True)
+    patch_generation_ignore_paths = fields.List(fields.String())
 
     # list of deprecated keys and their replacement (new,old)
     deprecated_keys = (("upstream_package_name", "upstream_project_name"),)

--- a/tests/data/sourcegit/source_git/.packit.yaml
+++ b/tests/data/sourcegit/source_git/.packit.yaml
@@ -4,6 +4,7 @@ synced_files:
   - src: fedora/beer.spec
     dest: beer.spec
   - .packit.yaml
+patch_generation_ignore_paths: ["ignored_file.txt"]
 upstream_project_name: beerware
 downstream_package_name: beer
 jobs:

--- a/tests/data/sourcegit/source_git/ignored_file.txt
+++ b/tests/data/sourcegit/source_git/ignored_file.txt
@@ -1,0 +1,1 @@
+I am being ignored.

--- a/tests/integration/test_source_git.py
+++ b/tests/integration/test_source_git.py
@@ -83,6 +83,10 @@ def test_basic_local_update_patch_content(
     source_file.write_text("new changes")
     git_add_and_commit(directory=sourcegit, message="source change")
 
+    source_file = sourcegit / "ignored_file.txt"
+    source_file.write_text(" And I am sad.")
+    git_add_and_commit(directory=sourcegit, message="make a file sad")
+
     api_instance_source_git.sync_release("master", "0.1.0", upstream_ref="0.1.0")
 
     spec = Specfile(str(distgit / "beer.spec"))


### PR DESCRIPTION
we need to control this explicitly since upstream repo can contain paths
which are not present in downstream & release tarball

this patch also accounts for defaults to synced_files - packit.yaml and
the spec file

with this, I got past the %prep phase in https://github.com/packit-service/systemd-rhel8-flock/pull/9

Fixes #639

TODO:
* [x] write one test case