### PR TITLE
upstream,srpm: prepend dash in the changelog entry

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -479,7 +479,7 @@ class Upstream(PackitRepositoryBase):
         self._fix_spec_source(archive)
         self._fix_spec_prep(version)
 
-        msg = f"Development snapshot ({commit})"
+        msg = f"- Development snapshot ({commit})"
         self.specfile.set_spec_version(version=f"{version}", changelog_entry=msg)
 
     def _fix_spec_prep(self, version):

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -197,7 +197,15 @@ def test_create_srpm(upstream_instance, tmpdir):
     assert srpm.exists()
 
     srpm_path = Path(tmpdir).joinpath("custom.src.rpm")
+
+    ups.prepare_upstream_for_srpm_creation()
     srpm = ups.create_srpm(srpm_path=srpm_path)
+    r = re.compile(r"^- Development snapshot \(\w{8}\)$")
+    for l in ups.specfile.spec_content.section("%changelog"):
+        if r.match(l):
+            break
+    else:
+        assert False, "Didn't find the correct line in the spec file."
     assert srpm.exists()
     build_srpm(srpm)
 


### PR DESCRIPTION
correct:
```
* Mon Jan 20 2020 Jiri Popelka <jpopelka@redhat.com> - 0.8.1-1
- new upstream release 0.8.1
```

incorrect:
```
* Wed Jan 22 2020 Tomas Tomecek <ttomecek@redhat.com> - 0.8.2.dev4+g04baaf0-1
Development snapshot (04baaf00)
```