### PR TITLE
Update spec when getting versions from different branches

### DIFF
--- a/packit/status.py
+++ b/packit/status.py
@@ -84,6 +84,7 @@ class Status:
                     branch, base=f"remotes/origin/{branch}", setup_tracking=False
                 )
                 self.dg.checkout_branch(branch)
+                self.dg.specfile.update_spec()
             except Exception as ex:
                 logger.debug(f"Branch {branch} is not present: {ex}")
                 continue


### PR DESCRIPTION
Fixes #679 
This works for me, it seems that spec file was loaded only for the first branch in the list of branches before.