### PR TITLE
[get_package_config_from_repo] Don't print a message for every not-found file.

### DIFF
--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -230,30 +230,35 @@ def get_package_config_from_repo(
             config_file_content = sourcegit_project.get_file_content(
                 path=config_file_name, ref=ref
             )
+        except FileNotFoundError:
+            # do nothing
+            pass
+        else:
             logger.debug(
                 f"Found a config file '{config_file_name}' "
                 f"on ref '{ref}' "
                 f"of the {sourcegit_project.full_repo_name} repository."
             )
-        except FileNotFoundError:
-            continue
-
-        try:
-            loaded_config = safe_load(config_file_content)
-        except Exception as ex:
-            logger.error(f"Cannot load package config '{config_file_name}'.")
-            raise PackitConfigException(f"Cannot load package config: {ex}.")
-        return parse_loaded_config(
-            loaded_config=loaded_config,
-            config_file_path=config_file_name,
-            repo_name=sourcegit_project.repo,
+            break
+    else:
+        logger.warning(
+            f"No config file ({CONFIG_FILE_NAMES}) found on ref '{ref}' "
+            f"of the {sourcegit_project.full_repo_name} repository."
         )
+        return None
 
-    logger.warning(
-        f"No config file ({CONFIG_FILE_NAMES}) found on ref '{ref}' "
-        f"of the {sourcegit_project.full_repo_name} repository."
+    try:
+        loaded_config = safe_load(config_file_content)
+    except Exception as ex:
+        logger.error(f"Cannot load package config {config_file_name!r}. {ex}")
+        raise PackitConfigException(
+            f"Cannot load package config {config_file_name!r}. {ex}"
+        )
+    return parse_loaded_config(
+        loaded_config=loaded_config,
+        config_file_path=config_file_name,
+        repo_name=sourcegit_project.repo,
     )
-    return None
 
 
 def parse_loaded_config(

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -235,13 +235,7 @@ def get_package_config_from_repo(
                 f"on ref '{ref}' "
                 f"of the {sourcegit_project.full_repo_name} repository."
             )
-        except FileNotFoundError as ex:
-            logger.debug(
-                f"The config file '{config_file_name}' "
-                f"not found on ref '{ref}' "
-                f"of the {sourcegit_project.full_repo_name} repository."
-                f"{ex!r}"
-            )
+        except FileNotFoundError:
             continue
 
         try:
@@ -256,7 +250,7 @@ def get_package_config_from_repo(
         )
 
     logger.warning(
-        f"No config file found on ref '{ref}' "
+        f"No config file ({CONFIG_FILE_NAMES}) found on ref '{ref}' "
         f"of the {sourcegit_project.full_repo_name} repository."
     )
     return None


### PR DESCRIPTION
Seeing this in worker logs:
```
[DEBUG/ForkPoolWorker-1] The config file '.packit.yaml' not found on ref '120438a1201d74c74a085f5c8161e1e737dae55e' of the bkabrda/flexmock repository.FileNotFoundError("File '.packit.yaml' on 120438a1201d74c74a085f5c8161e1e737dae55e not found", UnknownObjectException(404, {'message': 'Not Found', 'documentation_url': 'https://developer.github.com/v3/repos/contents/#get-contents'}))
[DEBUG/ForkPoolWorker-1] Found a config file '.packit.yml' on ref '120438a1201d74c74a085f5c8161e1e737dae55e' of the bkabrda/flexmock repository.
```

Current code goes through `[".packit.yaml", ".packit.yml",  ".packit.json",  "packit.yaml", "packit.yml", "packit.json"]` and spits a warning for every not-found config file.
So if the user named the config `packit.json`, we'd see 5 warnings, even everything is OK.

One warning if there's none of the files should be enough.