### PR TITLE
WIP: srpm: use relative paths

### DIFF
--- a/packit/utils.py
+++ b/packit/utils.py
@@ -30,6 +30,7 @@ import sys
 import tempfile
 import threading
 from contextlib import contextmanager
+from itertools import takewhile
 from pathlib import Path
 from typing import Tuple, Any, Optional, Dict, Union, List
 from urllib.parse import urlparse

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -20,10 +20,12 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import os
+import sys
 
 import pytest
-import sys
 from flexmock import flexmock
+from pkg_resources import DistributionNotFound, Distribution
 
 from packit.exceptions import PackitException, ensure_str
 from packit.utils import (
@@ -32,7 +34,6 @@ from packit.utils import (
     run_command,
     get_packit_version,
 )
-from pkg_resources import DistributionNotFound, Distribution
 
 
 @pytest.mark.parametrize(
@@ -100,3 +101,10 @@ def test_get_packit_version():
 )
 def test_ensure_str(inp, exp):
     assert ensure_str(inp) == exp
+
+
+@pytest.mark.parametrize(
+    "to,from_,exp", (("/", "/", "."), ("/a", "/a/b", ".."), ("/a", "/c", "../a"))
+)
+def test_relative_to(to, from_, exp):
+    assert os.path.relpath(to, from_) == exp


### PR DESCRIPTION
https://github.com/packit-service/packit-service/issues/344
https://github.com/packit-service/packit-service/issues/363

so that we have one set of variables we can use both in sandcastle and
locally in packit CLI

CC @lbarcziova