### PR TITLE
Change the paths in srpm build command

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -559,15 +559,15 @@ class Upstream(PackitRepositoryBase):
         :param srpm_dir: path to the directory where the srpm is meant to be placed
         :return: path to the srpm
         """
+
         if self.running_in_service():
             srpm_dir = "."
-            rpmbuild_dir = "."
-            src_dir = str(
-                self.absolute_specfile_dir.relative_to(self.local_project.working_dir)
+            rpmbuild_dir = os.path.relpath(
+                str(self.absolute_specfile_dir), self.local_project.working_dir
             )
         else:
             srpm_dir = srpm_dir or os.getcwd()
-            src_dir = rpmbuild_dir = str(self.absolute_specfile_dir)
+            rpmbuild_dir = str(self.absolute_specfile_dir)
 
         cmd = [
             "rpmbuild",
@@ -575,12 +575,11 @@ class Upstream(PackitRepositoryBase):
             "--define",
             f"_sourcedir {rpmbuild_dir}",
             f"--define",
-            f"_srcdir {src_dir}",
+            f"_srcdir {rpmbuild_dir}",
             "--define",
             f"_specdir {rpmbuild_dir}",
             "--define",
             f"_srcrpmdir {srpm_dir}",
-            # no idea about this one, but tests were failing in tox w/o it
             "--define",
             f"_topdir {rpmbuild_dir}",
             # we also need these 3 so that rpmbuild won't create them

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -21,9 +21,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import pytest
+import os
 import sys
+import pytest
+
 from flexmock import flexmock
+from pkg_resources import DistributionNotFound, Distribution
 
 from packit.exceptions import PackitException, ensure_str
 from packit.utils import (
@@ -32,7 +35,6 @@ from packit.utils import (
     run_command,
     get_packit_version,
 )
-from pkg_resources import DistributionNotFound, Distribution
 
 
 @pytest.mark.parametrize(
@@ -100,3 +102,10 @@ def test_get_packit_version():
 )
 def test_ensure_str(inp, exp):
     assert ensure_str(inp) == exp
+
+
+@pytest.mark.parametrize(
+    "to,from_,exp", (("/", "/", "."), ("/a", "/a/b", ".."), ("/a", "/c", "../a"))
+)
+def test_relative_to(to, from_, exp):
+    assert os.path.relpath(to, from_) == exp


### PR DESCRIPTION
Fixes packit-service/packit-service#344
Tested on the stage in packit-service/hello-world#78

I was trying to use #690 but in packit CLI it was not working with '.' paths and local tests were failing, so I left it in if-else (service-cli).