### PR TITLE
Remove command for renewing kerberos ticket

### DIFF
--- a/packit/fedpkg.py
+++ b/packit/fedpkg.py
@@ -129,20 +129,16 @@ class FedPKG:
 
     def init_ticket(self, keytab: str = None):
         # TODO: this method has nothing to do with fedpkg, pull it out
-        if not keytab and not self.fas_username:
+        if not self.fas_username or not keytab or not Path(keytab).is_file():
             logger.info("won't be doing kinit, no credentials provided")
             return
-        if keytab and Path(keytab).is_file():
-            cmd = [
-                "kinit",
-                f"{self.fas_username}@FEDORAPROJECT.ORG",
-                "-k",
-                "-t",
-                keytab,
-            ]
-        else:
-            # there is no keytab, but user still might have active ticket - try to renew it
-            cmd = ["kinit", "-R", f"{self.fas_username}@FEDORAPROJECT.ORG"]
+        cmd = [
+            "kinit",
+            f"{self.fas_username}@FEDORAPROJECT.ORG",
+            "-k",
+            "-t",
+            keytab,
+        ]
         return utils.run_command_remote(
             cmd=cmd, error_message="Failed to init kerberos ticket:", fail=True
         )


### PR DESCRIPTION
After discussion with @TomasTomecek yesterday I changed the init_ticket method - when no keytab is given, kinit is not called.

This should enable #689 to work without kerberos, I tried the fedpkg clone with your config and it works.