### PR TITLE
[spec] BuildRequires:  python3-copr

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -21,6 +21,7 @@ BuildRequires:  python3-packaging
 BuildRequires:  python3-pyyaml
 BuildRequires:  python3-tabulate
 BuildRequires:  python3-cccolutils
+BuildRequires:  python3-copr
 BuildRequires:  python3-koji
 BuildRequires:  python3-lazy-object-proxy
 BuildRequires:  rebase-helper


### PR DESCRIPTION
It is pulled in as a dependency of something else,
but rather be explicit to avoid surprices.