### PR TITLE
Revert "Define defaults for spec_source_id in PackageConfig"

### DIFF
--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -63,7 +63,7 @@ class PackageConfig:
         upstream_ref: Optional[str] = None,
         allowed_gpg_keys: Optional[List[str]] = None,
         create_pr: bool = True,
-        spec_source_id: Optional[str] = None,
+        spec_source_id: str = "Source0",
         upstream_tag_template: str = "{version}",
         patch_generation_ignore_paths: List[str] = None,
         **kwargs,
@@ -86,12 +86,7 @@ class PackageConfig:
         self.upstream_ref: Optional[str] = upstream_ref
         self.allowed_gpg_keys = allowed_gpg_keys
         self.create_pr: bool = create_pr
-        # By default the first one of (Source0, Source) found in the spec file is used.
-        # See https://github.com/packit-service/packit/issues/536#issuecomment-534074925
-        self.spec_source_id: List[str] = [spec_source_id] if spec_source_id else [
-            "Source0",
-            "Source",
-        ]
+        self.spec_source_id: str = spec_source_id
 
         # command to generate a tarball from the upstream repo
         # uncommitted changes will not be present in the archive

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -526,17 +526,30 @@ class Upstream(PackitRepositoryBase):
         self.specfile.write_spec_content()
 
     def _fix_spec_source(self, archive):
-        tag = None
-        for t in self.package_config.spec_source_id:
-            tag = self.specfile.tag(t)
-            if tag:
+        prefix = "Source"
+        regex = re.compile(r"^Source\s*:.+$")
+        for line in self.specfile.spec_content.section("%package"):
+            # we are looking for Source lines
+            if line.startswith(prefix):
+                # it's a Source line!
+                if line.startswith(self.package_config.spec_source_id):
+                    # it even matches the specific Source\d+
+                    full_name = self.package_config.spec_source_id
+                elif regex.match(line):
+                    # okay, let's try the other very common default
+                    # https://github.com/packit-service/packit/issues/536#issuecomment-534074925
+                    full_name = prefix
+                else:
+                    # nope, let's continue the search
+                    continue
+                # we found it!
                 break
         else:
             raise PackitException(
                 "The spec file doesn't have sources set "
-                f"via {' or '.join(self.package_config.spec_source_id)}."
+                f"via {self.package_config.spec_source_id} nor {prefix}."
             )
-        self.specfile.set_tag(tag.name, archive)
+        self.specfile.set_tag(full_name, archive)
 
     def create_srpm(self, srpm_path: str = None, srpm_dir: str = None) -> Path:
         """


### PR DESCRIPTION
This reverts commit 2693daeeae94e5dfb9343cf69178d83173c6b6dd.