### PR TITLE
[PackageConfig.get_specfile_path_from_repo()] rewrite & unit test

### DIFF
--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -305,7 +305,7 @@ def parse_loaded_config(
         raise PackitConfigException(f"Cannot parse package config: {ex}.")
 
 
-def get_local_specfile_path(directories: Union[List[str], List[Path]]):
+def get_local_specfile_path(directories: Union[List[str], List[Path]]) -> Optional[str]:
     """
     Get the relative path of the local spec file if present.
     :param directories: dirs to find the spec file
@@ -321,14 +321,14 @@ def get_local_specfile_path(directories: Union[List[str], List[Path]]):
     return None
 
 
-def get_specfile_path_from_repo(project: GitProject):
+def get_specfile_path_from_repo(project: GitProject) -> Optional[str]:
     """
     Get the path of the spec file in the given repo if present.
     :param project: GitProject
-    :return: str path of the spec file
+    :return: str path of the spec file or None
     """
-    try:
-        return project.get_files(filter_regex=".*.spec")[0]
-    except Exception as ex:
-        logger.debug(f"Cannot find the spec file: {ex}")
+    spec_files = project.get_files(filter_regex=r".*.spec")
+    if not spec_files:
+        logger.debug(f"No spec file found in {project.full_repo_name}")
         return None
+    return spec_files[0]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -575,6 +575,7 @@ def test_get_package_config_from_repo(content):
     gp = flexmock(GitProject)
     gp.should_receive("full_repo_name").and_return("a/b")
     gp.should_receive("get_file_content").and_return(content)
+    gp.should_receive("get_files").and_return(["packit.spec"])
     git_project = GitProject(repo="", service=GitService(), namespace="")
     config = get_package_config_from_repo(sourcegit_project=git_project, ref="")
     assert isinstance(config, PackageConfig)

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -1,0 +1,16 @@
+import pytest
+from flexmock import flexmock
+
+from ogr.abstract import GitProject, GitService
+from packit.config.package_config import get_specfile_path_from_repo
+
+
+@pytest.mark.parametrize(
+    "files,expected", [(["foo.spec"], "foo.spec"), ([], None)],
+)
+def test_get_specfile_path_from_repo(files, expected):
+    gp = flexmock(GitProject)
+    gp.should_receive("full_repo_name").and_return("a/b")
+    gp.should_receive("get_files").and_return(files)
+    git_project = GitProject(repo="", service=GitService(), namespace="")
+    assert get_specfile_path_from_repo(project=git_project) == expected


### PR DESCRIPTION
I found `DEBUG/ForkPoolWorker-1] Cannot find the spec file: list index out of range` in logs quite confusing, so I rewrote the method and added a unit test.