### PR TITLE
Split job and jobconfig (packit)

### DIFF
--- a/packit/config/__init__.py
+++ b/packit/config/__init__.py
@@ -5,7 +5,11 @@ from packit.config.config import (
     get_default_map_from_file,
     pass_config,
 )
-from packit.config.job_config import JobConfig, JobTriggerType, JobType
+from packit.config.job_config import (
+    JobConfig,
+    JobConfigTriggerType,
+    JobType,
+)
 from packit.config.package_config import (
     PackageConfig,
     get_package_config_from_repo,
@@ -21,7 +25,7 @@ from packit.config.sync_files_config import (
 __all__ = [
     Config.__name__,
     JobConfig.__name__,
-    JobTriggerType.__name__,
+    JobConfigTriggerType.__name__,
     JobType.__name__,
     PackageConfig.__name__,
     RawSyncFilesItem.__name__,

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -36,6 +36,7 @@ class JobType(Enum):
     build = "build"
     sync_from_downstream = "sync_from_downstream"
     copr_build = "copr_build"
+    production_build = "production_build"  # koji build
     add_to_whitelist = "add_to_whitelist"
     tests = "tests"
     report_test_results = "report_test_results"
@@ -44,24 +45,21 @@ class JobType(Enum):
     copr_build_started = "copr_build_started"
 
 
-class JobTriggerType(Enum):
+class JobConfigTriggerType(Enum):
     release = "release"
     pull_request = "pull_request"
     commit = "commit"
-    installation = "installation"
-    testing_farm_results = "testing_farm_results"
-    comment = "comment"
 
 
 class JobConfig:
-    def __init__(self, job: JobType, trigger: JobTriggerType, metadata: dict):
-        self.job = job
-        self.trigger = trigger
-        self.metadata = metadata
+    def __init__(self, type: JobType, trigger: JobConfigTriggerType, metadata: dict):
+        self.type = type
+        self.trigger: JobConfigTriggerType = trigger
+        self.metadata: dict = metadata
 
     def __repr__(self):
         return (
-            f"JobConfig(job={self.job}, trigger={self.trigger}, meta={self.metadata})"
+            f"JobConfig(job={self.type}, trigger={self.trigger}, meta={self.metadata})"
         )
 
     @classmethod
@@ -75,7 +73,7 @@ class JobConfig:
         if not isinstance(other, JobConfig):
             raise PackitConfigException("Provided object is not a JobConfig instance.")
         return (
-            self.job == other.job
+            self.type == other.type
             and self.trigger == other.trigger
             and self.metadata == other.metadata
         )
@@ -83,13 +81,13 @@ class JobConfig:
 
 default_jobs = [
     JobConfig(
-        job=JobType.tests,
-        trigger=JobTriggerType.pull_request,
+        type=JobType.tests,
+        trigger=JobConfigTriggerType.pull_request,
         metadata={"targets": ["fedora-stable"]},
     ),
     JobConfig(
-        job=JobType.propose_downstream,
-        trigger=JobTriggerType.release,
+        type=JobType.propose_downstream,
+        trigger=JobConfigTriggerType.release,
         metadata={"dist-git-branch": ["fedora-all"]},
     ),
 ]

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -25,11 +25,19 @@ import typing
 
 from marshmallow import Schema, fields, post_load, pre_load, ValidationError
 from marshmallow_enum import EnumField
+
 from packit.actions import ActionName
 from packit.config import PackageConfig, Config, SyncFilesConfig
-from packit.config.job_config import JobType, JobTriggerType, JobConfig, default_jobs
-from packit.config.package_config import NotificationsConfig
-from packit.config.package_config import PullRequestNotificationsConfig
+from packit.config.job_config import (
+    JobType,
+    JobConfig,
+    default_jobs,
+    JobConfigTriggerType,
+)
+from packit.config.package_config import (
+    NotificationsConfig,
+    PullRequestNotificationsConfig,
+)
 from packit.sync import SyncFilesItem
 
 logger = logging.getLogger(__name__)
@@ -108,6 +116,8 @@ class NotProcessedField(fields.Field):
     """
     Field class to mark fields which wil not be processed, only generates warning.
     Can be passed additional message via additional_message parameter.
+
+    :param str additional_message: additional warning message to be displayed
     """
 
     def _serialize(self, value: typing.Any, attr: str, obj: typing.Any, **kwargs):
@@ -159,12 +169,13 @@ class JobConfigSchema(Schema):
     """
 
     job = EnumField(JobType, required=True)
-    trigger = EnumField(JobTriggerType, required=True)
+    trigger = EnumField(JobConfigTriggerType, required=True)
     metadata = fields.Dict(missing={})
 
     @post_load
-    def make_instance(self, data, **kwargs):
-        return JobConfig(**data)
+    def make_instance(self, data, **_):
+        type = data.pop("job")
+        return JobConfig(type=type, **data)
 
 
 class PullRequestNotificationsSchema(Schema):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -33,12 +33,12 @@ from packit.actions import ActionName
 from packit.config import (
     Config,
     JobConfig,
-    JobTriggerType,
     JobType,
     PackageConfig,
     get_package_config_from_repo,
     SyncFilesConfig,
     SyncFilesItem,
+    JobConfigTriggerType,
 )
 from packit.config.package_config import get_local_specfile_path
 from tests.spellbook import UP_OSBUILD, SYNC_FILES
@@ -57,13 +57,15 @@ def get_job_config_dict_full():
 
 
 def get_job_config_simple():
-    return JobConfig(job=JobType.build, trigger=JobTriggerType.release, metadata={})
+    return JobConfig(
+        type=JobType.build, trigger=JobConfigTriggerType.release, metadata={}
+    )
 
 
 def get_job_config_full():
     return JobConfig(
-        job=JobType.propose_downstream,
-        trigger=JobTriggerType.pull_request,
+        type=JobType.propose_downstream,
+        trigger=JobConfigTriggerType.pull_request,
         metadata={"a": "b"},
     )
 
@@ -71,13 +73,13 @@ def get_job_config_full():
 def get_default_job_config():
     return [
         JobConfig(
-            job=JobType.tests,
-            trigger=JobTriggerType.pull_request,
+            type=JobType.tests,
+            trigger=JobConfigTriggerType.pull_request,
             metadata={"targets": ["fedora-stable"]},
         ),
         JobConfig(
-            job=JobType.propose_downstream,
-            trigger=JobTriggerType.release,
+            type=JobType.propose_downstream,
+            trigger=JobConfigTriggerType.release,
             metadata={"dist-git-branch": ["fedora-all"]},
         ),
     ]
@@ -515,7 +517,7 @@ def test_package_config_parse(raw, expected):
     # tests for https://github.com/packit-service/packit-service/pull/342
     if expected.jobs:
         for j in package_config.jobs:
-            assert j.job
+            assert j.type
     assert package_config == expected
 
 


### PR DESCRIPTION
- Split the JobTriggerType to one related to config and one for actual triggers.