### PR TITLE
packit, don't touch version, change release

### DIFF
--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -113,6 +113,7 @@ class PackageConfig:
         self.current_version_command: List[str] = current_version_command or [
             "git",
             "describe",
+            "--abbrev=0",
             "--tags",
             "--match",
             "*",


### PR DESCRIPTION
Example:
```
packit-0.8.1-1.20200305174322588258.104.g14f3e25.fc31.src.rpm
```

TODO:
* [x] get rid of the version stuff
* [x] doks - actually, there is not much to document here
* [x] fix tests
* [x] The template string for the release is not gonna be configurable.
* [x] test this with our biggest customers to make sure we're not breaking them (tried with packit, ogr, osbuild and tmt)

Fixes #693

Signed-off-by: Tomas Tomecek <ttomecek@redhat.com>