### PR TITLE
Add reverse-dep tests for packit-service

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -10,6 +10,7 @@
         - packit-tests-rpm-sess-rec
         - packit-tests-pip-deps-sess-rec
         - packit-tests-git-master-sess-rec
+        - reverse-dep-packit-service-tests
     gate:
       jobs:
         - packit-pre-commit
@@ -19,6 +20,7 @@
         - packit-tests-rpm-sess-rec
         - packit-tests-pip-deps-sess-rec
         - packit-tests-git-master-sess-rec
+        - reverse-dep-packit-service-tests
 
 - job:
     name: packit-pre-commit
@@ -91,3 +93,19 @@
     parent: packit-tests-git-master
     description: Run session recording tests of packit via pip installed dependencies
     run: files/zuul-tests-session-recording.yaml
+
+- job:
+    name: reverse-dep-packit-service-tests
+    parent: base
+    description: Run packit-service tests to check if we do not break packit-service
+    required-projects:
+      - github.com/packit-service/packit-service
+    pre-run: files/zuul-install-requirements-pip.yaml
+    run: files/zuul-reverse-dep-packit-service.yaml
+    extra-vars:
+      with_testing: true
+      ansible_python_interpreter: /usr/bin/python3
+    nodeset:
+      nodes:
+        - name: test-node
+          label: cloud-fedora-31

--- a/files/tasks/install-ansible.yaml
+++ b/files/tasks/install-ansible.yaml
@@ -1,0 +1,7 @@
+---
+- name: Install ansible
+  dnf:
+    name:
+      - ansible
+    state: present
+  become: true

--- a/files/tasks/install-packit-service.yaml
+++ b/files/tasks/install-packit-service.yaml
@@ -1,0 +1,5 @@
+---
+- name: Install packit-service
+  pip:
+    name: "{{ reverse_dir }}"
+  become: true

--- a/files/tasks/packit-service-requirements.yaml
+++ b/files/tasks/packit-service-requirements.yaml
@@ -1,0 +1,23 @@
+---
+- name: Install packit-service dependencies via ansible playbooks
+  command: ansible-playbook -e "ansible_python_interpreter=/usr/bin/python3" -v -c local -i localhost, files/install-deps.yaml
+  args:
+    chdir: "{{ reverse_dir }}"
+  become: true
+
+- name: Install packit-service dependencies via ansible playbooks
+  command: ansible-playbook -e "ansible_python_interpreter=/usr/bin/python3" -v -c local -i localhost, files/recipe-tests.yaml
+  args:
+    chdir: "{{ reverse_dir }}"
+  become: true
+
+- name: Create a config directory
+  file:
+    path: "{{ ansible_user_dir }}/.config"
+    state: directory
+
+- name: Create a symlink to service config
+  file:
+    src: "{{ reverse_dir}}/files/packit-service.yaml"
+    dest: "{{ ansible_user_dir }}/.config/packit-service.yaml"
+    state: link

--- a/files/zuul-reverse-dep-packit-service.yaml
+++ b/files/zuul-reverse-dep-packit-service.yaml
@@ -1,0 +1,15 @@
+---
+- name: Check if we are not breaking packit-service
+  hosts: all
+  tasks:
+    - set_fact:
+        reverse_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/packit-service/packit-service'].src_dir }}"
+    - include_tasks: tasks/zuul-project-setup.yaml
+    - include_tasks: tasks/install-ansible.yaml
+    - include_tasks: tasks/packit-service-requirements.yaml
+    - include_tasks: tasks/install-packit-service.yaml
+    - include_tasks: tasks/install-packit.yaml
+    - name: Run unit, integration tests
+      command: make check
+      args:
+        chdir: "{{ reverse_dir }}"


### PR DESCRIPTION
It should work now, here I tried to break the [p-s](https://softwarefactory-project.io/zuul/t/local/build/6cceea5e201c4565bacba19d4f888046) and it failed.
Fixes #742 