### PR TITLE
More Specfile.add_patches() changes

### DIFF
--- a/packit/specfile.py
+++ b/packit/specfile.py
@@ -146,7 +146,8 @@ class Specfile(SpecFile):
             new_content += "\n# " + "\n# ".join(msg.split("\n"))
             new_content += f"\nPatch{(i + 1):04d}: {patch}\n"
 
-        last_source_tag = [t for t in self.tags.filter(name="Source*")][-1]
+        # valid=None: take any SourceX even if it's disabled
+        last_source_tag = [t for t in self.tags.filter(name="Source*", valid=None)][-1]
         where = last_source_tag.line + 1
         # insert new content below last Source
         self.spec_content.section("%package")[where:where] = new_content.split("\n")

--- a/packit/specfile.py
+++ b/packit/specfile.py
@@ -148,7 +148,16 @@ class Specfile(SpecFile):
 
         # valid=None: take any SourceX even if it's disabled
         last_source_tag = [t for t in self.tags.filter(name="Source*", valid=None)][-1]
-        where = last_source_tag.line + 1
+        # find the first empty line after last_source_tag
+        for i, line in enumerate(
+            self.spec_content.section("%package")[last_source_tag.line:]
+        ):
+            if line.strip() == "":
+                break
+        else:
+            logger.error("Can't find where to add patches.")
+            return
+        where = last_source_tag.line + i
         # insert new content below last Source
         self.spec_content.section("%package")[where:where] = new_content.split("\n")
 

--- a/packit/specfile.py
+++ b/packit/specfile.py
@@ -147,17 +147,19 @@ class Specfile(SpecFile):
             new_content += f"\nPatch{(i + 1):04d}: {patch}\n"
 
         # valid=None: take any SourceX even if it's disabled
-        last_source_tag = [t for t in self.tags.filter(name="Source*", valid=None)][-1]
+        last_source_tag_line = [
+            t.line for t in self.tags.filter(name="Source*", valid=None)
+        ][-1]
         # find the first empty line after last_source_tag
         for i, line in enumerate(
-            self.spec_content.section("%package")[last_source_tag.line:]
+            self.spec_content.section("%package")[last_source_tag_line:]
         ):
             if line.strip() == "":
                 break
         else:
             logger.error("Can't find where to add patches.")
             return
-        where = last_source_tag.line + i
+        where = last_source_tag_line + i
         # insert new content below last Source
         self.spec_content.section("%package")[where:where] = new_content.split("\n")
 

--- a/tests/data/dist_git/beer.spec
+++ b/tests/data/dist_git/beer.spec
@@ -6,7 +6,9 @@ Release:        1%{?dist}
 Summary:        A tool to make you happy
 
 License:        Beerware
+%if 0%{?fedora} >= 28
 Source0:        %{upstream_name}-%{version}.tar.gz
+%endif
 BuildArch:      noarch
 
 %description

--- a/tests/data/sourcegit/source_git/fedora/beer.spec
+++ b/tests/data/sourcegit/source_git/fedora/beer.spec
@@ -6,7 +6,9 @@ Release:        1%{?dist}
 Summary:        A tool to make you happy
 
 License:        Beerware
+%if 0%{?fedora} >= 28
 Source0:        %{upstream_name}-%{version}.tar.gz
+%endif
 BuildArch:      noarch
 
 %description

--- a/tests/integration/test_source_git.py
+++ b/tests/integration/test_source_git.py
@@ -103,13 +103,20 @@ def test_basic_local_update_patch_content(
         in git_diff
     )
 
-    assert "+# PATCHES FROM SOURCE GIT:" in git_diff
-    spec_package_section = ""
-    for section in Specfile(distgit / "beer.spec").spec_content.sections:
-        if "%package" in section[0]:
-            spec_package_section += "\n".join(section[1])
-    assert "Patch0001: 0001-source-change.patch" in spec_package_section
-    assert "Patch0002:" not in spec_package_section  # no empty patches
+    assert (
+        """
++# PATCHES FROM SOURCE GIT:
++
++# source change
++# Author: Packit Test Suite <test@example.com>
++Patch0001: 0001-source-change.patch
++
++
+ %description
+"""
+        in git_diff
+    )
+    assert "Patch0002:" not in git_diff  # no empty patches
 
     assert (
         """ %prep


### PR DESCRIPTION
SourceX might be in a macro and I don't see a better way how to not add the patches inside the macro.