### PR TITLE
source-git: patch generation fixes:

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -314,7 +314,7 @@ class PackitRepositoryBase:
         logger.debug(f"Action command output: {outputs}")
         return outputs
 
-    def specfile_add_patches(self, patch_list: List[Tuple[str, str]]) -> None:
+    def specfile_add_patches(self, patch_list: List[Tuple[Path, str]]) -> None:
         """
         Add the given list of (patch_name, msg) to the specfile.
 

--- a/packit/specfile.py
+++ b/packit/specfile.py
@@ -126,7 +126,7 @@ class Specfile(SpecFile):
             self._process_patches(comment_out=indexes)
 
     @saves
-    def add_patches(self, patch_list: List[Tuple[str, str]]) -> None:
+    def add_patches(self, patch_list: List[Tuple[Path, str]]) -> None:
         """
         Add given patches to the specfile.
 
@@ -144,7 +144,7 @@ class Specfile(SpecFile):
         new_content = "\n# PATCHES FROM SOURCE GIT:\n"
         for i, (patch, msg) in enumerate(patch_list):
             new_content += "\n# " + "\n# ".join(msg.split("\n"))
-            new_content += f"\nPatch{(i + 1):04d}: {patch}\n"
+            new_content += f"\nPatch{(i + 1):04d}: {patch.name}\n"
 
         # valid=None: take any SourceX even if it's disabled
         last_source_tag_line = [

--- a/tests/spellbook.py
+++ b/tests/spellbook.py
@@ -100,7 +100,10 @@ def initiate_git_repo(
     if copy_from:
         shutil.copytree(copy_from, directory)
     subprocess.check_call(["git", "init", "."], cwd=directory)
-    Path(directory).joinpath("README").write_text("Best upstream project ever!")
+    directory_path = Path(directory)
+    directory_path.joinpath("README").write_text("Best upstream project ever!")
+    # this file is in the tarball
+    directory_path.joinpath("hops").write_text("Cascade\n")
     git_set_user_email(directory)
     subprocess.check_call(["git", "add", "."], cwd=directory)
     subprocess.check_call(["git", "commit", "-m", "initial commit"], cwd=directory)
@@ -119,6 +122,19 @@ def initiate_git_repo(
         subprocess.check_call(
             ["git", "push", "--tags", "-u", "origin", "master:master"], cwd=directory
         )
+
+
+def create_merge_commit_in_source_git(sg: Path):
+    hops = sg.joinpath("hops")
+    subprocess.check_call(["git", "checkout", "-B", "new-changes"], cwd=sg)
+    hops.write_text("Amarillo\n")
+    git_add_and_commit(directory=sg, message="switching to amarillo hops")
+    hops.write_text("Citra\n")
+    git_add_and_commit(directory=sg, message="actually, let's do citra")
+    subprocess.check_call(["git", "checkout", "master"], cwd=sg)
+    subprocess.check_call(
+        ["git", "merge", "--no-ff", "-m", "MERGE COMMIT!", "new-changes"], cwd=sg,
+    )
 
 
 def prepare_dist_git_repo(directory, push=True):


### PR DESCRIPTION
* order all patches we generate (merge commits were screwing this)
* a merge commit can produce multiple patch files

Fixes: https://stg.packit.dev/copr-build/141/logs