### PR TITLE
Marshmallow v3 support

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -24,6 +24,8 @@ BuildRequires:  python3-cccolutils
 BuildRequires:  python3-copr
 BuildRequires:  python3-koji
 BuildRequires:  python3-lazy-object-proxy
+BuildRequires:  python3-marshmallow
+BuildRequires:  python3-marshmallow-enum
 BuildRequires:  rebase-helper
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(setuptools-scm)

--- a/packit/config/config.py
+++ b/packit/config/config.py
@@ -96,6 +96,19 @@ class Config:
         # if kwargs:
         #     logger.warning(f"Following kwargs were not processed:" f"{kwargs}")
 
+    def __repr__(self):
+        return (
+            "Config("
+            f"debug='{self.debug}', "
+            f"fas_user='{self.fas_user}', "
+            f"keytab_path='{self.keytab_path}', "
+            f"command_handler='{self.command_handler}', "
+            f"command_handler_work_dir='{self.command_handler_work_dir}', "
+            f"command_handler_pvc_env_var='{self.command_handler_pvc_env_var}', "
+            f"command_handler_image_reference='{self.command_handler_image_reference}', "
+            f"command_handler_k8s_namespace='{self.command_handler_k8s_namespace}')"
+        )
+
     @classmethod
     def get_user_config(cls) -> "Config":
         xdg_config_home = os.getenv("XDG_CONFIG_HOME")

--- a/packit/config/config.py
+++ b/packit/config/config.py
@@ -137,7 +137,8 @@ class Config:
         # required to avoid cyclical imports
         from packit.schema import UserConfigSchema
 
-        config = UserConfigSchema(strict=True).load(raw_dict).data
+        config = UserConfigSchema().load(raw_dict)
+        logger.debug(config)
 
         return config
 

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -65,9 +65,15 @@ class JobConfig:
     @classmethod
     def get_from_dict(cls, raw_dict: dict) -> "JobConfig":
         # required to avoid cyclical imports
-        from packit.schema import JobConfigSchema
+        from packit.schema import JobConfigSchema, MM3
 
-        return JobConfigSchema(strict=True).load(raw_dict).data
+        if MM3:
+            config = JobConfigSchema().load(raw_dict)
+        else:  # v2
+            config = JobConfigSchema(strict=True).load(raw_dict).data
+        logger.debug(config)
+
+        return config
 
     def __eq__(self, other: object):
         if not isinstance(other, JobConfig):

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -173,7 +173,7 @@ class PackageConfig:
         if config_file_path and not raw_dict.get("config_file_path", None):
             raw_dict.update(config_file_path=config_file_path)
 
-        package_config = PackageConfigSchema(strict=True).load(raw_dict).data
+        package_config = PackageConfigSchema().load(raw_dict)
 
         if not getattr(package_config, "specfile_path", None):
             if spec_file_path:
@@ -190,6 +190,7 @@ class PackageConfig:
         if "jobs" not in raw_dict:
             package_config.jobs = default_jobs
 
+        logger.debug(package_config)
         return package_config
 
     def get_all_files_to_sync(self):

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -122,6 +122,30 @@ class PackageConfig:
         if kwargs:
             logger.warning(f"Following kwargs were not processed:" f"{kwargs}")
 
+    def __repr__(self):
+        return (
+            "PackageConfig("
+            f"config_file_path='{self.config_file_path}', "
+            f"specfile_path='{self.specfile_path}', "
+            f"synced_files='{self.synced_files}', "
+            f"jobs='{self.jobs}', "
+            f"dist_git_namespace='{self.dist_git_namespace}', "
+            f"upstream_project_url='{self.upstream_project_url}', "
+            f"upstream_package_name='{self.upstream_package_name}', "
+            f"downstream_project_url='{self.downstream_project_url}', "
+            f"downstream_package_name='{self.downstream_package_name}', "
+            f"dist_git_base_url='{self.dist_git_base_url}', "
+            f"create_tarball_command='{self.create_tarball_command}', "
+            f"current_version_command='{self.current_version_command}', "
+            f"actions='{self.actions}', "
+            f"upstream_ref='{self.upstream_ref}', "
+            f"allowed_gpg_keys='{self.allowed_gpg_keys}', "
+            f"create_pr='{self.create_pr}', "
+            f"spec_source_id='{self.spec_source_id}', "
+            f"upstream_tag_template='{self.upstream_tag_template}', "
+            f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}')"
+        )
+
     @property
     def downstream_project_url(self) -> str:
         if not self._downstream_project_url:

--- a/packit/config/sync_files_config.py
+++ b/packit/config/sync_files_config.py
@@ -50,9 +50,15 @@ class SyncFilesConfig:
     @classmethod
     def get_from_dict(cls, raw_dict: dict) -> "SyncFilesConfig":
         # required to avoid cyclical imports
-        from packit.schema import SyncFilesConfigSchema
+        from packit.schema import SyncFilesConfigSchema, MM3
 
-        return SyncFilesConfigSchema(strict=True).load(raw_dict).data
+        if MM3:
+            config = SyncFilesConfigSchema().load(raw_dict)
+        else:  # v2
+            config = SyncFilesConfigSchema(strict=True).load(raw_dict).data
+        logger.debug(config)
+
+        return config
 
     def __eq__(self, other: object):
         if not isinstance(other, SyncFilesConfig):

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     copr
     jsonschema
     lazy_object_proxy
-    marshmallow<3
+    marshmallow
     marshmallow-enum
     munch
     ogr


### PR DESCRIPTION
To be merged together with https://github.com/packit-service/packit-service/pull/538

If you want to test with marshmallow-3, you can use [this rpm](https://jpopelka.fedorapeople.org/python3-marshmallow-3.1.1-2.fc32.noarch.rpm).

I was trying to inherit more of our classes (like `JobConfig`) from the [MM23Schema](https://github.com/packit-service/packit/pull/775/files#diff-bdfa782a63635e6f072bd2bc058a5683R148), but there's some advanced magic, which prevented me from doing that. Since this is a temporary code (until F31 is EOL) I can live with that, can you too?

I'll address #744 and #782 separately.