### PR TITLE
Fix web URLs for Copr builds owned by groups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,13 @@ Running tests locally:
 make check_in_container
 ```
 
+To select a subset of the whole test suite, set `TESTS_TARGET`. For example to
+run only the unit tests use:
+
+```
+TESTS_TARGET=tests/unit make check_in_container
+```
+
 As a CI we use [Zuul](https://softwarefactory-project.io/zuul/t/local/builds?project=packit-service/packit) with a configuration in [.zuul.yaml](.zuul.yaml).
 If you want to re-run CI/tests in a pull request, just include `recheck` in a comment.
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 IMAGE=docker.io/usercont/packit
 TESTS_IMAGE=packit-tests
 TESTS_RECORDING_PATH=tests_recording
-TESTS_CONTAINER_RUN=podman run --rm -ti -v $(CURDIR):/src --security-opt label=disable $(TESTS_IMAGE)
-TESTS_TARGET := ./tests/unit ./tests/integration ./tests/functional
+TESTS_CONTAINER_RUN=podman run --rm -ti -v $(CURDIR):/src --env-host --security-opt label=disable $(TESTS_IMAGE)
+TESTS_TARGET ?= ./tests/unit ./tests/integration ./tests/functional
 
 # To build base image for packit-service-worker
 image:

--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -33,13 +33,14 @@ class CoprHelper:
     def configured_owner(self):
         return self.copr_client.config.get("username")
 
-    @staticmethod
-    def copr_web_build_url(build: Munch):
+    def copr_web_build_url(self, build: Munch) -> str:
         """ Construct web frontend url because build.repo_url is not much user-friendly."""
-        return (
-            "https://copr.fedorainfracloud.org/coprs/"
-            f"{build.ownername}/{build.projectname}/build/{build.id}/"
-        )
+        copr_url = self.copr_client.config.get("copr_url")
+        ownername = build.ownername
+        if ownername.startswith("@"):
+            # the owner is a group, so the URL is slightly different
+            ownername = ownername.replace("@", "g/", 1)
+        return f"{copr_url}/coprs/{ownername}/{build.projectname}/build/{build.id}/"
 
     def create_copr_project_if_not_exists(
         self,

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -21,41 +21,75 @@
 # SOFTWARE.
 
 from munch import Munch
-from pytest import fixture
+import pytest
+import flexmock
 
 from packit.copr_helper import CoprHelper
 
 
-@fixture()
-def copr_build():
+def build_dict(owner, copr_url):
+    """Create a build object which uses 'owner' and 'copr_url'."""
     # copr_client.build_proxy.get(build_id) response
-    build_dict = {
-        "chroots": ["fedora-29-x86_64", "fedora-30-x86_64", "fedora-rawhide-x86_64"],
-        "ended_on": 1566377991,
-        "id": 1010428,
-        "ownername": "packit",
-        "project_dirname": "packit-service-ogr-160",
-        "projectname": "packit-service-ogr-160",
-        "repo_url": "https://copr-be.cloud.fedoraproject.org/results/packit/packit-service-ogr-160",
-        "source_package": {
-            "name": "python-ogr",
-            "url": "https://copr-be.cloud.fedoraproject.org/results/"
-            "packit/packit-service-ogr-160/srpm-builds/01010428/"
-            "python-ogr-0.6.1.dev51ge88ac83-1.fc30.src.rpm",
-            "version": "0.6.1.dev51+ge88ac83-1.fc30",
-        },
-        "started_on": 1566377844,
-        "state": "succeeded",
-        "submitted_on": 1566377764,
-        "submitter": "packit",
-    }
-    web_build_url = (
-        "https://copr.fedorainfracloud.org/coprs/"
-        "packit/packit-service-ogr-160/build/1010428/"
+    return Munch(
+        {
+            "chroots": [
+                "fedora-29-x86_64",
+                "fedora-30-x86_64",
+                "fedora-rawhide-x86_64",
+            ],
+            "ended_on": 1566377991,
+            "id": 1010428,
+            "ownername": f"{owner}",
+            "project_dirname": "packit-service-ogr-160",
+            "projectname": "packit-service-ogr-160",
+            "repo_url": f"{copr_url}/results/packit/packit-service-ogr-160",
+            "source_package": {
+                "name": "python-ogr",
+                "url": "https://copr-be.cloud.fedoraproject.org/results/"
+                "packit/packit-service-ogr-160/srpm-builds/01010428/"
+                "python-ogr-0.6.1.dev51ge88ac83-1.fc30.src.rpm",
+                "version": "0.6.1.dev51+ge88ac83-1.fc30",
+            },
+            "started_on": 1566377844,
+            "state": "succeeded",
+            "submitted_on": 1566377764,
+            "submitter": "packit",
+        }
     )
-    return Munch(build_dict), web_build_url
 
 
+def copr_helper(copr_url):
+    """Create a mock CoprHelper, with a copr_client configured with 'copr_url'."""
+    helper = CoprHelper(flexmock())
+    helper._copr_client = flexmock(config={"copr_url": copr_url})
+    return helper
+
+
+testdata = [
+    pytest.param(
+        copr_helper("https://supr.copr"),
+        build_dict("packit", "https://supr.copr"),
+        "https://supr.copr/coprs/packit/packit-service-ogr-160/build/1010428/",
+        id="user",
+    ),
+    pytest.param(
+        copr_helper("https://group.copr"),
+        build_dict("@oamg", "https://group.copr"),
+        "https://group.copr/coprs/g/oamg/packit-service-ogr-160/build/1010428/",
+        id="group",
+    ),
+    pytest.param(
+        copr_helper("https://mean.copr"),
+        build_dict("me@n", "https://mean.copr"),
+        "https://mean.copr/coprs/me@n/packit-service-ogr-160/build/1010428/",
+        id="mean_user",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "helper,build,web_url", testdata,
+)
 class TestPackitAPI:
-    def test__copr_web_build_url(self, copr_build):
-        assert CoprHelper.copr_web_build_url(copr_build[0]) == copr_build[1]
+    def test_copr_web_build_url(self, helper, build, web_url):
+        assert helper.copr_web_build_url(build) == web_url


### PR DESCRIPTION
In Copr, when a namespace belongs to a group, its name starts with '@'.
URLs to builds in the Copr web UI though use the 'g/' token, instead of
'@'.

Take the above into account when generating URLs for the log pages.

Relates to packit-service/packit-service#523.