### PR TITLE
change the way how packit does archives

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -502,7 +502,6 @@ class PackitAPI:
             raise PackitSRPMException(
                 f"Preparing of the upstream to the SRPM build failed: {ex}"
             ) from ex
-
         try:
             srpm_path = self.up.create_srpm(srpm_path=output_file, srpm_dir=srpm_dir)
         except PackitSRPMException:

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -31,7 +31,8 @@ CONFIG_FILE_NAMES = [
     "packit.json",
 ]
 
-COMMON_ARCHIVE_EXTENSIONS = [".tar.gz", ".tar.bz2", ".tar.xz", ".zip"]
+# we create .tar.gz archives
+DEFAULT_ARCHIVE_EXT = ".tar.gz"
 
 # fedmsg topics
 URM_NEW_RELEASE_TOPIC = "org.release-monitoring.prod.anitya.project.version.update"

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -90,3 +90,5 @@ SYNCING_NOTE = (
     "This repository is maintained by packit.\nhttps://packit.dev/\n"
     "The file was generated using packit {packit_version}.\n"
 )
+
+SPEC_PACKAGE_SECTION = "%package"

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -354,21 +354,6 @@ class Upstream(PackitRepositoryBase):
 
         return ver
 
-    def get_archive_extension(self, archive_basename: str, version: str) -> str:
-        """
-        Obtains archive extension from SpecFile based on basename of the archive.
-        Defaults to .tar.gz if no Source corresponds to the basename.
-        """
-        for source in self.specfile.get_sources():
-            base = os.path.basename(source)
-            # Version in archive_basename could contain hash, the version
-            # can be different from Spec version. Replace it to ensure proper match.
-            base = base.replace(self.specfile.get_version(), version)
-            if base.startswith(archive_basename):
-                archive_basename_len = len(archive_basename)
-                return base[archive_basename_len:]
-        return ".tar.gz"
-
     def create_archive(self, version: str = None) -> str:
         """
         Create archive, using `git archive` by default, from the content of the upstream
@@ -412,14 +397,7 @@ class Upstream(PackitRepositoryBase):
 
         :return: name of the archive
         """
-        archive_extension = self.get_archive_extension(dir_name, version)
-        if archive_extension not in COMMON_ARCHIVE_EXTENSIONS:
-            raise PackitException(
-                "The target archive doesn't use a common extension ({}), "
-                "git archive can't be used. Please provide your own script "
-                "for archive creation.".format(", ".join(COMMON_ARCHIVE_EXTENSIONS))
-            )
-        archive_name = f"{dir_name}{archive_extension}"
+        archive_name = f"{dir_name}{DEFAULT_ARCHIVE_EXT}"
         relative_archive_path = (self.absolute_specfile_dir / archive_name).relative_to(
             self.local_project.working_dir
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,52 +14,46 @@ from tests.spellbook import (
     DG_OGR,
     UPSTREAM_SPEC_NOT_IN_ROOT,
     UPSTREAM_WITH_MUTLIPLE_SOURCES,
+    UPSTREAM_WEIRD_SOURCES,
 )
+
+
+def get_git_repo_and_remote(
+    target_dir: Path, repo_template_path: Path
+) -> Tuple[Path, Path]:
+    """
+    :param target_dir: tmpdir from pytest - we'll work here
+    :param repo_template_path: git repo template from tests/data/
+    """
+    u_remote_path = target_dir / f"upstream_remote-{repo_template_path.name}"
+    u_remote_path.mkdir(parents=True, exist_ok=True)
+    subprocess.check_call(["git", "init", "--bare", "."], cwd=u_remote_path)
+
+    u = target_dir / f"local_clone-{repo_template_path.name}"
+    shutil.copytree(repo_template_path, u)
+    initiate_git_repo(u, tag="0.1.0", push=True, upstream_remote=str(u_remote_path))
+
+    return u, u_remote_path
 
 
 @pytest.fixture()
 def upstream_and_remote(tmpdir) -> Tuple[Path, Path]:
-    t = Path(str(tmpdir))
-
-    u_remote_path = t / "upstream_remote"
-    u_remote_path.mkdir(parents=True, exist_ok=True)
-    subprocess.check_call(["git", "init", "--bare", "."], cwd=u_remote_path)
-
-    u = t / "upstream_git"
-    shutil.copytree(UPSTREAM, u)
-    initiate_git_repo(u, tag="0.1.0", push=True, upstream_remote=str(u_remote_path))
-
-    return u, u_remote_path
+    return get_git_repo_and_remote(Path(tmpdir), UPSTREAM)
 
 
 @pytest.fixture()
 def upstream_and_remote_with_multiple_sources(tmpdir) -> Tuple[Path, Path]:
-    t = Path(str(tmpdir))
-
-    u_remote_path = t / "upstream_git_with_multiple_sources_remote"
-    u_remote_path.mkdir(parents=True, exist_ok=True)
-    subprocess.check_call(["git", "init", "--bare", "."], cwd=u_remote_path)
-
-    u = t / "upstream_git_with_multiple_sources"
-    shutil.copytree(UPSTREAM_WITH_MUTLIPLE_SOURCES, u)
-    initiate_git_repo(u, tag="0.1.0", push=True, upstream_remote=str(u_remote_path))
-
-    return u, u_remote_path
+    return get_git_repo_and_remote(Path(tmpdir), UPSTREAM_WITH_MUTLIPLE_SOURCES)
 
 
 @pytest.fixture()
-def upstream_spec_not_in_root(tmpdir) -> Path:
-    t = Path(str(tmpdir))
+def upstream_and_remote_weird_sources(tmpdir) -> Tuple[Path, Path]:
+    return get_git_repo_and_remote(Path(tmpdir), UPSTREAM_WEIRD_SOURCES)
 
-    u_remote_path = t / "upstream_remote"
-    u_remote_path.mkdir(parents=True, exist_ok=True)
-    subprocess.check_call(["git", "init", "--bare", "."], cwd=u_remote_path)
 
-    u = t / "upstream_git"
-    shutil.copytree(UPSTREAM_SPEC_NOT_IN_ROOT, u)
-    initiate_git_repo(u, tag="0.1.0", push=True, upstream_remote=str(u_remote_path))
-
-    return u
+@pytest.fixture()
+def upstream_spec_not_in_root(tmpdir) -> Tuple[Path, Path]:
+    return get_git_repo_and_remote(Path(tmpdir), UPSTREAM_SPEC_NOT_IN_ROOT)
 
 
 @pytest.fixture()

--- a/tests/data/dist_git/.packit.json
+++ b/tests/data/dist_git/.packit.json
@@ -4,5 +4,5 @@
   "upstream_package_name": "beerware",
   "downstream_package_name": "beer",
   "create_pr": false,
-  "upstream_project_url": "../upstream_remote"
+  "upstream_project_url": "../upstream_remote-upstream_git"
 }

--- a/tests/data/snapd/packaging/fedora/fix-spec
+++ b/tests/data/snapd/packaging/fedora/fix-spec
@@ -8,8 +8,8 @@ test `printenv PACKIT_PROJECT_ARCHIVE` = "snapd-2.41.tar.gz"
 
 p="packaging/fedora"
 
-no_vendor="$(ls -1 ./*.no-vendor.tar.xz | xargs basename)"
-vendor="$(ls -1 ./*.only-vendor.tar.xz | xargs basename)"
+no_vendor="$(ls -1 ./packaging/fedora/*.no-vendor.tar.xz | xargs basename)"
+vendor="$(ls -1 ./packaging/fedora/*.only-vendor.tar.xz | xargs basename)"
 
 sed -i $p/snapd.spec -e "s/https.*no-vendor.tar.xz/$no_vendor/"
 sed -i $p/snapd.spec -e "s/https.*only-vendor.tar.xz/$vendor/"

--- a/tests/data/snapd/packaging/fedora/pack-source
+++ b/tests/data/snapd/packaging/fedora/pack-source
@@ -56,11 +56,11 @@ tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
 if [[ "$single" == 0 ]]; then
-    tar -cJf "$tmpdir"/snapd_"$version".no-vendor.tar.xz --exclude='vendor/*' --exclude='.git/*' --transform "s#^#snapd-$version/#" .
-    tar -cJf "$tmpdir"/snapd_"$version".only-vendor.tar.xz --exclude='.git/*' --transform "s#^#snapd-$version/#" vendor
+    tar -cJf "$tmpdir/snapd_$version.no-vendor.tar.xz" --exclude='vendor/*' --exclude='.git/*' --transform "s#^#snapd-$version/#" .
+    tar -cJf "$tmpdir/snapd_$version.only-vendor.tar.xz" --exclude='.git/*' --transform "s#^#snapd-$version/#" vendor
 
-    mv "$tmpdir"/snapd_"$version".no-vendor.tar.xz "$outdir"/
-    mv "$tmpdir"/snapd_"$version".only-vendor.tar.xz "$outdir"/
+    mv "$tmpdir/snapd_$version.no-vendor.tar.xz" "$outdir/packaging/fedora/"
+    mv "$tmpdir/snapd_$version.only-vendor.tar.xz" "$outdir/packaging/fedora/"
 else
     tar -cJf "$tmpdir"/snapd_"$version".vendor.tar.xz --exclude='.git/*' --transform "s#^#snapd-$version/#" .
     mv "$tmpdir"/snapd_"$version".vendor.tar.xz "$outdir"/

--- a/tests/data/upstream_git_weird_sources/.packit.json
+++ b/tests/data/upstream_git_weird_sources/.packit.json
@@ -1,0 +1,5 @@
+{
+  "specfile_path": "beer.spec",
+  "upstream_package_name": "beerware",
+  "downstream_package_name": "beer"
+}

--- a/tests/data/upstream_git_weird_sources/beer.spec
+++ b/tests/data/upstream_git_weird_sources/beer.spec
@@ -1,0 +1,20 @@
+%global upstream_name beerware
+
+Name:           beer
+Version:        0.1.0
+Release:        1%{?dist}
+Summary:        A tool to make you happy
+
+License:        Beerware
+Source:         we-have-totally-weird-archive-name.tar.gz
+BuildArch:      noarch
+
+%description
+...but not too happy.
+
+%prep
+%autosetup -n %{upstream_name}-%{version}
+
+%changelog
+* Mon Feb 25 2019 Tomas Tomecek <ttomecek@redhat.com> - 0.1.0-1
+- Initial brewing

--- a/tests/functional/test_srpm.py
+++ b/tests/functional/test_srpm.py
@@ -58,8 +58,16 @@ def test_srpm_command(cwd_upstream_or_distgit):
 
 
 def test_srpm_spec_not_in_root(upstream_spec_not_in_root):
-    call_real_packit(parameters=["--debug", "srpm"], cwd=upstream_spec_not_in_root)
-    srpm_path = list(upstream_spec_not_in_root.glob("*.src.rpm"))[0]
+    call_real_packit(parameters=["--debug", "srpm"], cwd=upstream_spec_not_in_root[0])
+    srpm_path = list(upstream_spec_not_in_root[0].glob("*.src.rpm"))[0]
+    assert srpm_path.exists()
+    build_srpm(srpm_path)
+
+
+def test_srpm_weird_sources(upstream_and_remote_weird_sources):
+    repo = upstream_and_remote_weird_sources[0]
+    call_real_packit(parameters=["--debug", "srpm"], cwd=repo)
+    srpm_path = list(repo.glob("*.src.rpm"))[0]
     assert srpm_path.exists()
     build_srpm(srpm_path)
 

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -162,17 +162,16 @@ def test_create_archive(upstream_instance, extension):
 
     ups.create_archive()
 
-    # there is still only one archive - we no longer use --long git-describe
-    # by default, upstreams should handle versions themselves
-    assert len(list(u.glob(f"*{extension}"))) == 1
+    # we enforce .tar.gz now
+    assert len(list(u.glob("*.tar.gz"))) == 1
 
 
 def test_create_uncommon_archive(upstream_instance):
     u, ups = upstream_instance
     change_source_ext(ups, ".cpio")
-
-    with pytest.raises(PackitException):
-        ups.create_archive()
+    ups.create_archive()
+    # we enforce .tar.gz now
+    assert len(list(u.glob("*.tar.gz"))) == 1
 
 
 def test_fix_spec(upstream_instance):

--- a/tests/spellbook.py
+++ b/tests/spellbook.py
@@ -38,6 +38,7 @@ TESTS_DIR = Path(__file__).parent
 DATA_DIR = TESTS_DIR / "data"
 UPSTREAM = DATA_DIR / "upstream_git"
 UPSTREAM_WITH_MUTLIPLE_SOURCES = DATA_DIR / "upstream_git_with_multiple_sources"
+UPSTREAM_WEIRD_SOURCES = DATA_DIR / "upstream_git_weird_sources"
 EMPTY_CHANGELOG = DATA_DIR / "empty_changelog"
 DISTGIT = DATA_DIR / "dist_git"
 UP_COCKPIT_OSTREE = DATA_DIR / "cockpit-ostree"


### PR DESCRIPTION
Fixes #708

1. `self.specfile.set_tag(full_name, archive)` did not do anything to the spec file: hence I implemented it differently by replacing the %package section

2. we were checking extension of the archive in Source - we no longer need to do that since we now change the %setup line - we always create tar.gz now and let %setup process it