### PR TITLE
Be explicit about the env vars passed in 'make check_in_container'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMAGE=docker.io/usercont/packit
 TESTS_IMAGE=packit-tests
 TESTS_RECORDING_PATH=tests_recording
-TESTS_CONTAINER_RUN=podman run --rm -ti -v $(CURDIR):/src --env-host --security-opt label=disable $(TESTS_IMAGE)
+TESTS_CONTAINER_RUN=podman run --rm -ti -v $(CURDIR):/src --env TESTS_TARGET --security-opt label=disable $(TESTS_IMAGE)
 TESTS_TARGET ?= ./tests/unit ./tests/integration ./tests/functional
 
 # To build base image for packit-service-worker


### PR DESCRIPTION
In 30dbc5b I thought it's a good idea to pass all environment variables
from the host in the container where the checks are executed.

It turned out, passing `HOME` causes `git config` to look for
username and email configuration at the wrong place.

In order to keep things under control, be explicit about which
environment variables are passed from the host to the container. So far
this is only `TESTS_TARGET`.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>