### PR TITLE
Guess CONTAINER_ENGINE when using 'make'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,22 @@
 IMAGE=docker.io/usercont/packit
 TESTS_IMAGE=packit-tests
+
+CONTAINER_ENGINE ?= $(shell command -v podman 2> /dev/null || echo docker)
+TESTS_CONTAINER_RUN=$(CONTAINER_ENGINE) run --rm -ti -v $(CURDIR):/src --env TESTS_TARGET --security-opt label=disable $(TESTS_IMAGE)
 TESTS_RECORDING_PATH=tests_recording
-TESTS_CONTAINER_RUN=podman run --rm -ti -v $(CURDIR):/src --env TESTS_TARGET --security-opt label=disable $(TESTS_IMAGE)
 TESTS_TARGET ?= ./tests/unit ./tests/integration ./tests/functional
+
 
 # To build base image for packit-service-worker
 image:
-	docker build --rm -t $(IMAGE) .
+	$(CONTAINER_ENGINE) build --rm -t $(IMAGE) .
 
 tests_image:
-	podman build --tag $(TESTS_IMAGE) -f Dockerfile.tests .
+	$(CONTAINER_ENGINE) build --tag $(TESTS_IMAGE) -f Dockerfile.tests .
 	sleep 2
 
 tests_image_remove:
-	podman rmi $(TESTS_IMAGE)
+	$(CONTAINER_ENGINE) rmi $(TESTS_IMAGE)
 
 install:
 	pip3 install --user .


### PR DESCRIPTION
Instead of requiring to set the CONTAINER_ENGINE environment variable
for 'make' to choose 'podman' instead of 'docker', try to guess it by
first trying 'podman', and defaulting to 'docker' only if that failed.

Seen in the OpenShift docs:
https://docs.openshift.com/container-platform/4.2/openshift_images/create-images.html#testing-locally_create-images