### PR TITLE
Add 'branch' attribute to job metadata

### DIFF
--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -59,6 +59,7 @@ class JobMetadataConfig:
         owner: str = None,
         project: str = None,
         dist_git_branch: str = None,
+        branch: str = None,
     ):
         """
         :param targets: copr_build job, mock chroots where to build
@@ -66,12 +67,14 @@ class JobMetadataConfig:
         :param owner: copr_build, a namespace in COPR where the build should happen
         :param project: copr_build, a name of the copr project
         :param dist_git_branch: propose_downstream, a branch in dist-git where packit should work
+        :param branch: for `commit` trigger to specify the branch name
         """
         self.targets = targets or []
         self.timeout: int = timeout
         self.owner: str = owner
         self.project: str = project
         self.dist_git_branch: str = dist_git_branch
+        self.branch: str = branch
 
     def __repr__(self):
         return (
@@ -79,7 +82,8 @@ class JobMetadataConfig:
             f"timeout={self.timeout}, "
             f"owner={self.owner}, "
             f"project={self.project}, "
-            f"dist_git_branch={self.dist_git_branch})"
+            f"dist_git_branch={self.dist_git_branch},"
+            f"branch={self.branch})"
         )
 
     def __eq__(self, other: object):
@@ -93,6 +97,7 @@ class JobMetadataConfig:
             and self.owner == other.owner
             and self.project == other.project
             and self.dist_git_branch == other.dist_git_branch
+            and self.branch == other.branch
         )
 
 

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -206,6 +206,7 @@ class JobMetadataSchema(Schema):
     owner = fields.String()
     project = fields.String()
     dist_git_branch = fields.String()
+    branch = fields.String()
 
     @pre_load
     def ordered_preprocess(self, data, **_):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -71,6 +71,22 @@ def job_config_full():
     return get_job_config_full()
 
 
+def get_job_config_dict_build_for_branch():
+    return {
+        "job": "copr_build",
+        "trigger": "commit",
+        "metadata": {"branch": "build-branch"},
+    }
+
+
+def get_job_config_build_for_branch():
+    return JobConfig(
+        type=JobType.copr_build,
+        trigger=JobConfigTriggerType.commit,
+        metadata=JobMetadataConfig(branch="build-branch"),
+    )
+
+
 def get_default_job_config():
     return [
         JobConfig(

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -3,14 +3,6 @@ from pathlib import Path
 import pytest
 from flexmock import flexmock
 from marshmallow import ValidationError
-from tests.spellbook import UP_OSBUILD, SYNC_FILES
-from tests.unit.test_config import (
-    get_job_config_dict_full,
-    get_job_config_dict_simple,
-    get_job_config_simple,
-    get_job_config_full,
-    get_default_job_config,
-)
 
 from ogr.abstract import GitProject, GitService
 from packit.actions import ActionName
@@ -29,6 +21,16 @@ from packit.config.package_config import (
 )
 from packit.schema import MM3
 from packit.sync import SyncFilesItem
+from tests.spellbook import UP_OSBUILD, SYNC_FILES
+from tests.unit.test_config import (
+    get_job_config_dict_full,
+    get_job_config_dict_simple,
+    get_job_config_simple,
+    get_job_config_full,
+    get_default_job_config,
+    get_job_config_dict_build_for_branch,
+    get_job_config_build_for_branch,
+)
 
 
 @pytest.fixture()
@@ -536,6 +538,17 @@ def test_package_config_parse_error(raw):
                 downstream_package_name="package",
             ),
             id="specfile_path+synced_files+downstream_package_name",
+        ),
+        pytest.param(
+            {
+                "specfile_path": "fedora/package.spec",
+                "jobs": [get_job_config_dict_build_for_branch()],
+            },
+            PackageConfig(
+                specfile_path="fedora/package.spec",
+                jobs=[get_job_config_build_for_branch()],
+            ),
+            id="specfile_path+get_job_config_dict_build_for_branch",
         ),
     ],
 )


### PR DESCRIPTION
- Add 'branch' attribute to metadata.
- Fixes #795