### PR TITLE
Rename job metadata dist_git_branch to dist_git_branches 

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,7 +17,7 @@ jobs:
   - job: propose_downstream
     trigger: release
     metadata:
-      dist_git_branch: fedora-all
+      dist_git_branches: fedora-all
   - job: sync_from_downstream
     trigger: commit
   - job: copr_build

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -22,7 +22,7 @@
 
 import logging
 from enum import Enum
-from typing import List
+from typing import List, Set
 
 from packit.exceptions import PackitConfigException
 
@@ -58,7 +58,7 @@ class JobMetadataConfig:
         timeout: int = 7200,
         owner: str = None,
         project: str = None,
-        dist_git_branch: str = None,
+        dist_git_branches: List[str] = None,
         branch: str = None,
         scratch: bool = False,
     ):
@@ -67,25 +67,28 @@ class JobMetadataConfig:
         :param timeout: copr_build, give up watching a build after timeout, defaults to 7200s
         :param owner: copr_build, a namespace in COPR where the build should happen
         :param project: copr_build, a name of the copr project
-        :param dist_git_branch: propose_downstream, a branch in dist-git where packit should work
+        :param dist_git_branches: propose_downstream, branches in dist-git where packit should work
         :param branch: for `commit` trigger to specify the branch name
         :param scratch: if we want to run scratch build in koji
         """
-        self.targets = targets or []
+        self.targets: List[str] = targets or []
         self.timeout: int = timeout
         self.owner: str = owner
         self.project: str = project
-        self.dist_git_branch: str = dist_git_branch
+        self.dist_git_branches: Set[str] = set(
+            dist_git_branches
+        ) if dist_git_branches else set()
         self.branch: str = branch
         self.scratch: bool = scratch
 
     def __repr__(self):
         return (
-            f"JobMetadataConfig(targets={self.targets}, "
+            f"JobMetadataConfig("
+            f"targets={self.targets}, "
             f"timeout={self.timeout}, "
             f"owner={self.owner}, "
             f"project={self.project}, "
-            f"dist_git_branch={self.dist_git_branch},"
+            f"dist_git_branches={self.dist_git_branches},"
             f"branch={self.branch},"
             f"scratch={self.scratch})"
         )
@@ -100,7 +103,7 @@ class JobMetadataConfig:
             and self.timeout == other.timeout
             and self.owner == other.owner
             and self.project == other.project
-            and self.dist_git_branch == other.dist_git_branch
+            and self.dist_git_branches == other.dist_git_branches
             and self.branch == other.branch
             and self.scratch == other.scratch
         )
@@ -154,6 +157,6 @@ default_jobs = [
     JobConfig(
         type=JobType.propose_downstream,
         trigger=JobConfigTriggerType.release,
-        metadata=JobMetadataConfig(dist_git_branch="fedora-all"),
+        metadata=JobMetadataConfig(dist_git_branches=["fedora-all"]),
     ),
 ]

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -20,13 +20,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import logging
+
 from enum import Enum
+from logging import getLogger
 from typing import List, Set
 
 from packit.exceptions import PackitConfigException
 
-logger = logging.getLogger(__name__)
+logger = getLogger(__name__)
 
 
 class JobType(Enum):
@@ -71,7 +72,7 @@ class JobMetadataConfig:
         :param branch: for `commit` trigger to specify the branch name
         :param scratch: if we want to run scratch build in koji
         """
-        self.targets: List[str] = targets or []
+        self.targets: Set[str] = set(targets) if targets else set()
         self.timeout: int = timeout
         self.owner: str = owner
         self.project: str = project

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -205,21 +205,23 @@ class JobMetadataSchema(Schema):
     timeout = fields.Integer()
     owner = fields.String()
     project = fields.String()
-    dist_git_branch = fields.String()
+    dist_git_branches = fields.List(fields.String())
     branch = fields.String()
     scratch = fields.Boolean()
 
     @pre_load
     def ordered_preprocess(self, data, **_):
-        if "dist-git-branch" in data:
-            logger.warning(
-                f"Job metadata key 'dist-git-branch' has been renamed to 'dist_git_branch', "
-                f"please update your configuration file."
-            )
-            data["dist_git_branch"] = data.pop("dist-git-branch")
-        if isinstance(data.get("targets"), str):
-            # allow "targets" being specified as string
-            data["targets"] = [data.pop("targets")]
+        for key in ("dist-git-branch", "dist_git_branch"):
+            if key in data:
+                logger.warning(
+                    f"Job metadata key {key!r} has been renamed to 'dist_git_branches', "
+                    f"please update your configuration file."
+                )
+                data["dist_git_branches"] = data.pop(key)
+        for key in ("targets", "dist_git_branches"):
+            if isinstance(data.get(key), str):
+                # allow key value being specified as string, convert to list
+                data[key] = [data.pop(key)]
         return data
 
     @post_load

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -62,7 +62,7 @@ def get_job_config_full():
     return JobConfig(
         type=JobType.propose_downstream,
         trigger=JobConfigTriggerType.pull_request,
-        metadata=JobMetadataConfig(dist_git_branch="master"),
+        metadata=JobMetadataConfig(dist_git_branches=["master"]),
     )
 
 
@@ -97,7 +97,7 @@ def get_default_job_config():
         JobConfig(
             type=JobType.propose_downstream,
             trigger=JobConfigTriggerType.release,
-            metadata=JobMetadataConfig(dist_git_branch="fedora-all"),
+            metadata=JobMetadataConfig(dist_git_branches=["fedora-all"]),
         ),
     ]
 

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -249,6 +249,21 @@ def test_package_config_not_equal(not_equal_package_config):
                 "specfile_path": "fedora/package.spec",
                 "jobs": [
                     {
+                        "job": "copr_build",
+                        "trigger": "release",
+                        "metadata": {
+                            "targets": ["fedora-stable", "fedora-development"]
+                        },
+                    }
+                ],
+            },
+            True,
+        ),
+        (
+            {
+                "specfile_path": "fedora/package.spec",
+                "jobs": [
+                    {
                         "job": "propose_downstream",
                         "trigger": "release",
                         "metadata": {

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -225,6 +225,19 @@ def test_package_config_not_equal(not_equal_package_config):
                     {
                         "job": "propose_downstream",
                         "trigger": "release",
+                        "metadata": {"dist_git_branches": ["fedora-all", "epel-8"]},
+                    }
+                ],
+            },
+            True,
+        ),
+        (
+            {
+                "specfile_path": "fedora/package.spec",
+                "jobs": [
+                    {
+                        "job": "copr_build",
+                        "trigger": "release",
                         "metadata": {"targets": "fedora-stable"},
                     }
                 ],


### PR DESCRIPTION
`dist_git_branch` (and older `dist-git-branch`) are still accepted, but deprecated

We need the key to be able to accept a list of strings (branches), not just one string.
Internally it's (and also `targets` now) stored as `Set[str]`, but it's loaded as `List[str]` from config (yaml doesn't know sets).