### PR TITLE
Add scratch to metadata

### DIFF
--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -60,6 +60,7 @@ class JobMetadataConfig:
         project: str = None,
         dist_git_branch: str = None,
         branch: str = None,
+        scratch: bool = False,
     ):
         """
         :param targets: copr_build job, mock chroots where to build
@@ -68,6 +69,7 @@ class JobMetadataConfig:
         :param project: copr_build, a name of the copr project
         :param dist_git_branch: propose_downstream, a branch in dist-git where packit should work
         :param branch: for `commit` trigger to specify the branch name
+        :param scratch: if we want to run scratch build in koji
         """
         self.targets = targets or []
         self.timeout: int = timeout
@@ -75,6 +77,7 @@ class JobMetadataConfig:
         self.project: str = project
         self.dist_git_branch: str = dist_git_branch
         self.branch: str = branch
+        self.scratch: bool = scratch
 
     def __repr__(self):
         return (
@@ -83,7 +86,8 @@ class JobMetadataConfig:
             f"owner={self.owner}, "
             f"project={self.project}, "
             f"dist_git_branch={self.dist_git_branch},"
-            f"branch={self.branch})"
+            f"branch={self.branch},"
+            f"scratch={self.scratch})"
         )
 
     def __eq__(self, other: object):
@@ -98,6 +102,7 @@ class JobMetadataConfig:
             and self.project == other.project
             and self.dist_git_branch == other.dist_git_branch
             and self.branch == other.branch
+            and self.scratch == other.scratch
         )
 
 

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -207,6 +207,7 @@ class JobMetadataSchema(Schema):
     project = fields.String()
     dist_git_branch = fields.String()
     branch = fields.String()
+    scratch = fields.Boolean()
 
     @pre_load
     def ordered_preprocess(self, data, **_):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -75,7 +75,7 @@ def get_job_config_dict_build_for_branch():
     return {
         "job": "copr_build",
         "trigger": "commit",
-        "metadata": {"branch": "build-branch"},
+        "metadata": {"branch": "build-branch", "scratch": True},
     }
 
 
@@ -83,7 +83,7 @@ def get_job_config_build_for_branch():
     return JobConfig(
         type=JobType.copr_build,
         trigger=JobConfigTriggerType.commit,
-        metadata=JobMetadataConfig(branch="build-branch"),
+        metadata=JobMetadataConfig(branch="build-branch", scratch=True),
     )
 
 


### PR DESCRIPTION
- Add 'scratch' attribute to metadata.
- Required by koji build.