### PR TITLE
Simplify URLs pointing to Copr builds

### DIFF
--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -36,11 +36,7 @@ class CoprHelper:
     def copr_web_build_url(self, build: Munch) -> str:
         """ Construct web frontend url because build.repo_url is not much user-friendly."""
         copr_url = self.copr_client.config.get("copr_url")
-        ownername = build.ownername
-        if ownername.startswith("@"):
-            # the owner is a group, so the URL is slightly different
-            ownername = ownername.replace("@", "g/", 1)
-        return f"{copr_url}/coprs/{ownername}/{build.projectname}/build/{build.id}/"
+        return f"{copr_url}/coprs/build/{build.id}/"
 
     def create_copr_project_if_not_exists(
         self,

--- a/tests/integration/test_copr_build.py
+++ b/tests/integration/test_copr_build.py
@@ -52,10 +52,7 @@ def test_copr_build_existing_project(cwd_upstream_or_distgit, api_instance):
     )
 
     assert build_id == "1"
-    assert url == (
-        "https://copr.fedorainfracloud.org/coprs/"
-        f"{build.ownername}/{build.projectname}/build/{build.id}/"
-    )
+    assert url == f"https://copr.fedorainfracloud.org/coprs/build/{build.id}/"
 
 
 def test_copr_build_non_existing_project(cwd_upstream_or_distgit, api_instance):
@@ -86,10 +83,7 @@ def test_copr_build_non_existing_project(cwd_upstream_or_distgit, api_instance):
     )
 
     assert build_id == "1"
-    assert url == (
-        "https://copr.fedorainfracloud.org/coprs/"
-        f"{build.ownername}/{build.projectname}/build/{build.id}/"
-    )
+    assert url == f"https://copr.fedorainfracloud.org/coprs/build/{build.id}/"
 
 
 def test_copr_build_no_owner(cwd_upstream_or_distgit, api_instance):

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -27,8 +27,8 @@ import flexmock
 from packit.copr_helper import CoprHelper
 
 
-def build_dict(owner, copr_url):
-    """Create a build object which uses 'owner' and 'copr_url'."""
+def build_dict(copr_url, id):
+    """Create a build object which uses 'copr_url' and 'id'."""
     # copr_client.build_proxy.get(build_id) response
     return Munch(
         {
@@ -38,8 +38,8 @@ def build_dict(owner, copr_url):
                 "fedora-rawhide-x86_64",
             ],
             "ended_on": 1566377991,
-            "id": 1010428,
-            "ownername": f"{owner}",
+            "id": str(id),
+            "ownername": "packit",
             "project_dirname": "packit-service-ogr-160",
             "projectname": "packit-service-ogr-160",
             "repo_url": f"{copr_url}/results/packit/packit-service-ogr-160",
@@ -68,21 +68,18 @@ def copr_helper(copr_url):
 testdata = [
     pytest.param(
         copr_helper("https://supr.copr"),
-        build_dict("packit", "https://supr.copr"),
-        "https://supr.copr/coprs/packit/packit-service-ogr-160/build/1010428/",
+        build_dict("https://supr.copr", 1010428),
+        "https://supr.copr/coprs/build/1010428/",
         id="user",
     ),
+    # The name "group" bellow is kept for historical reasons.
+    # These Copr permalinks have no information in them regarding who
+    # the owner of the build is (although they will have, once they redirect).
     pytest.param(
         copr_helper("https://group.copr"),
-        build_dict("@oamg", "https://group.copr"),
-        "https://group.copr/coprs/g/oamg/packit-service-ogr-160/build/1010428/",
+        build_dict("https://group.copr", 1010430),
+        "https://group.copr/coprs/build/1010430/",
         id="group",
-    ),
-    pytest.param(
-        copr_helper("https://mean.copr"),
-        build_dict("me@n", "https://mean.copr"),
-        "https://mean.copr/coprs/me@n/packit-service-ogr-160/build/1010428/",
-        id="mean_user",
     ),
 ]
 


### PR DESCRIPTION
In a [discussion with praiskup] I've learnt, that URLs pointing to Copr
builds don't have to contain the owner and project name. Providing only
a build id is enough, as such links will redirect to the proper owner
and project.

Considering the above this removes owner and project name from the Copr
build URLs, to simplify this code path.

[discussion with praiskup]: https://pagure.io/copr/copr/issue/1332

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>