### PR TITLE
let tests pass in TFT

### DIFF
--- a/files/tasks/rpm-test-deps.yaml
+++ b/files/tasks/rpm-test-deps.yaml
@@ -9,3 +9,9 @@
       - python3-setuptools_scm
     state: present
   become: true
+- name: Install rpmautospec-rpm-macros
+  dnf:
+    name:
+      - rpmautospec-rpm-macros
+    enablerepo: updates-testing
+  become: true


### PR DESCRIPTION
rpmautospec-rpm-macros needs to be installed so that we can process
ogr's spec with %autochangelog correctly