### PR TITLE
Save specfile after content sync

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -364,6 +364,7 @@ class PackitRepositoryBase:
         this_changelog = self.specfile.spec_content.section("%changelog")
         this_version = self.specfile.get_version()
         self.specfile.spec_content.sections[:] = specfile.spec_content.sections[:]
+        self.specfile.save()
         self.specfile.spec_content.replace_section("%changelog", this_changelog)
         self.specfile.set_version(this_version)
         self.specfile.save()

--- a/tests/data/upstream_git/beer.spec
+++ b/tests/data/upstream_git/beer.spec
@@ -1,5 +1,7 @@
 %global upstream_name beerware
 
+# some change
+
 Name:           beer
 Version:        0.1.0
 Release:        1%{?dist}

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -23,8 +23,8 @@ import subprocess
 from pathlib import Path
 
 import pytest
-
 from flexmock import flexmock
+
 from packit.api import PackitAPI, Config
 from packit.config import parse_loaded_config
 from packit.local_project import LocalProject
@@ -86,6 +86,15 @@ def test_basic_local_update_using_distgit(
     assert (d / TARBALL_NAME).is_file()
     spec = Specfile(d / "beer.spec")
     assert spec.get_version() == "0.1.0"
+
+    package_section = spec.spec_content.section("%package")
+
+    assert package_section[2] == "# some change"
+    assert package_section[4] == "Name:           beer"
+    assert package_section[5] == "Version:        0.1.0"
+    assert package_section[6] == "Release:        1%{?dist}"
+    assert package_section[7] == "Summary:        A tool to make you happy"
+
     assert (d / "README.packit").is_file()
     # assert that we have changelog entries for both versions
     changelog = "\n".join(spec.spec_content.section("%changelog"))


### PR DESCRIPTION
- Save the specfile to the file after the content sync
    
- Fixes: https://github.com/packit-service/packit/issues/828
    
- We need to force rebase-helper to refresh indices to save version to the correct line when upstream and downstream differs in the line number of the version.