### PR TITLE
Initialize kerberos for upstream koji build

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -28,8 +28,8 @@ from typing import Optional, Sequence, List
 import cccolutils
 import git
 import requests
-from ogr.abstract import PullRequest
 
+from ogr.abstract import PullRequest
 from packit.base_git import PackitRepositoryBase
 from packit.config import (
     Config,
@@ -269,7 +269,6 @@ class DistGit(PackitRepositoryBase):
         f = FedPKG(
             fas_username=self.config.fas_user, directory=self.local_project.working_dir
         )
-        f.init_ticket(self.config.keytab_path)
         try:
             f.new_sources(sources=archive_path)
         except Exception as ex:
@@ -317,7 +316,6 @@ class DistGit(PackitRepositoryBase):
         fpkg = FedPKG(
             fas_username=self.fas_user, directory=self.local_project.working_dir
         )
-        fpkg.init_ticket(self.config.keytab_path)
         fpkg.build(scratch=scratch, nowait=nowait, koji_target=koji_target)
 
     def create_bodhi_update(

--- a/packit/fedpkg.py
+++ b/packit/fedpkg.py
@@ -126,19 +126,3 @@ class FedPKG:
             f"SSH keys set up or Kerberos ticket being active."
         )
         utils.run_command(cmd=cmd, error_message=error_msg)
-
-    def init_ticket(self, keytab: str = None):
-        # TODO: this method has nothing to do with fedpkg, pull it out
-        if not self.fas_username or not keytab or not Path(keytab).is_file():
-            logger.info("Won't be doing kinit, no credentials provided.")
-            return
-        cmd = [
-            "kinit",
-            f"{self.fas_username}@FEDORAPROJECT.ORG",
-            "-k",
-            "-t",
-            keytab,
-        ]
-        return utils.run_command_remote(
-            cmd=cmd, error_message="Failed to init kerberos ticket:", fail=True
-        )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -27,9 +27,9 @@ from pathlib import Path
 from typing import Iterator
 
 import pytest
+from flexmock import flexmock
 from gnupg import GPG
 
-from flexmock import flexmock
 from ogr.abstract import PullRequest, PRStatus
 from ogr.services.github import GithubService, GithubProject
 from ogr.services.pagure import PagureProject, PagureService, PagureUser
@@ -38,8 +38,8 @@ from packit.cli.utils import get_packit_api
 from packit.config import get_local_package_config
 from packit.distgit import DistGit
 from packit.fedpkg import FedPKG
-from packit.specfile import Specfile
 from packit.local_project import LocalProject
+from packit.specfile import Specfile
 from packit.upstream import Upstream
 from packit.utils import cwd
 from tests.integration.utils import remove_gpg_key_pair
@@ -159,7 +159,8 @@ def mock_remote_functionality(distgit: Path, upstream: Path):
         if not Path(sources).is_file():
             raise RuntimeError("archive does not exist")
 
-    flexmock(FedPKG, init_ticket=lambda x=None: None, new_sources=mocked_new_sources)
+    flexmock(FedPKG, new_sources=mocked_new_sources)
+    flexmock(PackitAPI, init_kerberos_ticket=lambda: None)
     pc = get_local_package_config(str(upstream))
     pc.dist_git_clone_path = str(distgit)
     pc.upstream_project_url = str(upstream)

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -29,13 +29,13 @@ from pathlib import Path
 import pytest
 from flexmock import flexmock
 
+from packit import utils
 from packit.api import PackitAPI
 from packit.config import get_local_package_config
 from packit.distgit import DistGit
 from packit.fedpkg import FedPKG
 from packit.local_project import LocalProject
 from packit.utils import cwd
-from packit import utils
 from tests.spellbook import UP_COCKPIT_OSTREE, initiate_git_repo, get_test_config
 
 
@@ -65,7 +65,8 @@ def test_update_on_cockpit_ostree(cockpit_ostree):
         if not Path(sources).is_file():
             raise RuntimeError("archive does not exist")
 
-    flexmock(FedPKG, init_ticket=lambda x=None: None, new_sources=mocked_new_sources)
+    flexmock(FedPKG, new_sources=mocked_new_sources)
+    flexmock(PackitAPI, init_kerberos_ticket=lambda: None)
 
     flexmock(
         DistGit,


### PR DESCRIPTION
- Move initialization of the kerberos ticket to the api.
- Use it also for koji builds for upstream SRPM.