### PR TITLE
[Zuul reverse deps] Install worker dependencies

### DIFF
--- a/files/tasks/packit-service-requirements.yaml
+++ b/files/tasks/packit-service-requirements.yaml
@@ -12,6 +12,12 @@
     chdir: "{{ reverse_dir }}"
   become: true
 
+- name: Install packit-service-worker dependencies
+  command: ansible-playbook -e "ansible_python_interpreter=/usr/bin/python3" -v -c local -i localhost, files/install-deps-worker.yaml
+  args:
+    chdir: "{{ reverse_dir }}"
+  become: true
+
 - name: Install packit-service test dependencies
   command: ansible-playbook -e "ansible_python_interpreter=/usr/bin/python3" -v -c local -i localhost, files/recipe-tests.yaml
   args:


### PR DESCRIPTION
packit-service's tests need them.

See for example [this](https://softwarefactory-project.io/zuul/t/packit-service/build/29a2cf7fab14403396f390d92c0d15d3/log/job-output.txt)