### PR TITLE
fix tests in Fedora CI by installing setuptools_scm

### DIFF
--- a/fedora-tests/tests.yml
+++ b/fedora-tests/tests.yml
@@ -10,6 +10,7 @@
         - python3-tox
         - python3-pytest
         - python3-flexmock
+        - python3-setuptools_scm
         - make
         - krb5-devel
         - rpm-libs


### PR DESCRIPTION
https://jenkins-continuous-infra.apps.ci.centos.org/job/fedora-rawhide-pr-pipeline/3670/artifact/package-tests/logs/FAIL-str_upstream.log