### PR TITLE
Add copr build for master

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -30,3 +30,10 @@ jobs:
     metadata:
       targets:
         - fedora-stable # on rawhide we have problems with the new marshmallow
+  - job: copr_build
+    trigger: commit
+    metadata:
+      branch: master
+      targets:
+        - fedora-stable
+      project: packit-master

--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ $ pip3 install --user packitos
 You can also install packit from master branch, if you are brave enough:
 
 ```
+$ dnf copr enable packit/packit-master
+$ dnf install packit
+```
+
+Or
+
+```
 $ pip3 install --user git+https://github.com/packit-service/packit.git
 ```
 


### PR DESCRIPTION
- Add copr builds for master commits and update installation instructions.
- Why?
  - dog-fooding packit-service
  - Just that we can..;)
  - Someone may want to actually use that.