### PR TITLE
pc.set_job_overrides: do heavy lifting only when needed

### DIFF
--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -150,9 +150,12 @@ class PackageConfig:
         )
 
     def set_job_overrides(self, job: JobConfig):
-        d = deepcopy(self.raw_dict)
-        d.update(job.overrides)
-        self.__dict__ = PackageConfig.get_from_dict(d).__dict__
+        """ get job.overrides and overlay them over the current package_config """
+        if job.overrides:
+            # this is actually pretty expensive to do, so let's do it only when really needed
+            d = deepcopy(self.raw_dict)
+            d.update(job.overrides)
+            self.__dict__ = PackageConfig.get_from_dict(d).__dict__
 
     @property
     def downstream_project_url(self) -> str:


### PR DESCRIPTION
The override logic is using .get_from_dict which is pretty expensive
given it parses and validates the payload - let's not do all of that if
overrides are empty since it would be just a waste of cycles.

I need this in p-s PR because this is breaking ~50 tests which would
take me ages to fix.