### PR TITLE
logging improvements

### DIFF
--- a/packit/cli/build.py
+++ b/packit/cli/build.py
@@ -31,7 +31,7 @@ from packit.config import pass_config, get_context_settings
 from packit.config.aliases import get_branches
 from packit.exceptions import PackitCommandFailedError, ensure_str
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 @click.command("build", context_settings=get_context_settings())

--- a/packit/cli/create_update.py
+++ b/packit/cli/create_update.py
@@ -31,7 +31,7 @@ from packit.config import pass_config, get_context_settings
 from packit.config.aliases import get_branches
 from packit.constants import DEFAULT_BODHI_NOTE
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 @click.command("create-update", context_settings=get_context_settings())

--- a/packit/cli/packit_base.py
+++ b/packit/cli/packit_base.py
@@ -87,7 +87,7 @@ def packit_base(ctx, debug, fas_user, keytab, dry_run):
         set_logging(level=logging.INFO)
 
     packit_version = get_distribution("packitos").version
-    logger.info(f"Packit {packit_version} is being used.")
+    logger.debug(f"Packit {packit_version} is being used.")
 
 
 packit_base.add_command(update)

--- a/packit/cli/push_updates.py
+++ b/packit/cli/push_updates.py
@@ -34,7 +34,7 @@ from packit.cli.utils import cover_packit_exception
 from packit.cli.utils import get_packit_api
 from packit.config import pass_config, get_context_settings
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 @click.command("push-updates", context_settings=get_context_settings())

--- a/packit/cli/status.py
+++ b/packit/cli/status.py
@@ -34,7 +34,7 @@ from packit.cli.utils import cover_packit_exception
 from packit.cli.utils import get_packit_api
 from packit.config import pass_config, get_context_settings
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 @click.command("status", context_settings=get_context_settings())

--- a/packit/cli/sync_from_downstream.py
+++ b/packit/cli/sync_from_downstream.py
@@ -34,7 +34,7 @@ from packit.cli.utils import cover_packit_exception, get_packit_api
 from packit.config import pass_config, get_context_settings
 from packit.config.aliases import get_branches
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 @click.command("sync-from-downstream", context_settings=get_context_settings())

--- a/packit/cli/types.py
+++ b/packit/cli/types.py
@@ -62,12 +62,12 @@ class LocalProjectParameter(click.ParamType):
 
             if os.path.isdir(value):
                 absolute_path = os.path.abspath(value)
-                logger.info(f"Input is a directory: {absolute_path}")
+                logger.debug(f"Input is a directory: {absolute_path}")
                 local_project = LocalProject(
                     working_dir=absolute_path, ref=branch_name, remote=remote_name
                 )
             elif git_remote_url_to_https_url(value):
-                logger.info(f"Input is a URL to a git repo: {value}")
+                logger.debug(f"Input is a URL to a git repo: {value}")
                 local_project = LocalProject(
                     git_url=value, ref=branch_name, remote=remote_name
                 )

--- a/packit/cli/update.py
+++ b/packit/cli/update.py
@@ -34,7 +34,7 @@ from packit.cli.utils import cover_packit_exception, get_packit_api
 from packit.config import pass_config, get_context_settings
 from packit.config.aliases import get_branches
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 @click.command("propose-update", context_settings=get_context_settings())

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -340,12 +340,12 @@ class PackageConfigSchema(MM23Schema):
             downstream_package_name = data.get("downstream_package_name", None)
             if downstream_package_name:
                 data["specfile_path"] = f"{downstream_package_name}.spec"
-                logger.info(
-                    f"Setting `specfile_path` to {downstream_package_name}.spec."
+                logger.debug(
+                    f'Setting `specfile_path` to "./{downstream_package_name}.spec".'
                 )
             else:
                 # guess it?
-                logger.info(
+                logger.debug(
                     "Neither `specfile_path` nor `downstream_package_name` set."
                 )
         return data


### PR DESCRIPTION
```
logging: turn common statements to debug logs

These log statements are interesting to us, as packit devs, but not to
our users really - they don't care what packit version is being used, or
whether $PWD is a upstream repo. People care about what packit does and
what may be a problem.

Therefore I'm reducing these common statements which were printed all
the time to debug - if users run into problems, they can rerun with
`packit --debug` and give us all the meaningful info.
```

and

```
cli/*: use __name__ to construct a logger

__file__ gives us different logger than 'packit' logger, so let's do the
right thing:

ipdb> logger
<CustomLogger packit (INFO)>

ipdb> logging.getLogger(__file__)
<CustomLogger /home/tt/g/user-cont/packit/packit/cli/packit_base.py (WARNING)>
```