### PR TITLE
accept JobConfig and PackageConfig equally

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -28,17 +28,18 @@ import asyncio
 import logging
 import os
 import shutil
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Sequence, Callable, List, Tuple, Dict, Iterable, Optional
 
-import sys
+from ogr.abstract import PullRequest
 from tabulate import tabulate
 
-from ogr.abstract import PullRequest
 from packit import utils
 from packit.actions import ActionName
-from packit.config import Config, PackageConfig
+from packit.config import Config
+from packit.config.common_package_config import CommonPackageConfig
 from packit.constants import SYNCING_NOTE
 from packit.copr_helper import CoprHelper
 from packit.distgit import DistGit
@@ -63,12 +64,12 @@ class PackitAPI:
     def __init__(
         self,
         config: Config,
-        package_config: PackageConfig,
+        package_config: CommonPackageConfig,
         upstream_local_project: LocalProject = None,
         downstream_local_project: LocalProject = None,
     ) -> None:
         self.config = config
-        self.package_config = package_config
+        self.package_config: CommonPackageConfig = package_config
         self.upstream_local_project = upstream_local_project
         self.downstream_local_project = downstream_local_project
 

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -30,7 +30,8 @@ from git import PushInfo
 
 from packit.actions import ActionName
 from packit.command_handler import RUN_COMMAND_HANDLER_MAPPING, CommandHandler
-from packit.config import Config, PackageConfig, RunCommandType
+from packit.config import Config, RunCommandType
+from packit.config.common_package_config import CommonPackageConfig
 from packit.exceptions import PackitException
 from packit.local_project import LocalProject
 from packit.security import CommitVerifier
@@ -44,7 +45,7 @@ class PackitRepositoryBase:
     # mypy complains when this is a property
     local_project: LocalProject
 
-    def __init__(self, config: Config, package_config: PackageConfig) -> None:
+    def __init__(self, config: Config, package_config: CommonPackageConfig) -> None:
         """
         :param config: global configuration
         :param package_config: configuration of the upstream project

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -24,6 +24,8 @@ Common package config attributes so they can be imported both in PackageConfig a
 """
 from typing import Optional, List, Union, Dict
 
+from packit.sync import SyncFilesItem
+
 from packit.actions import ActionName
 from packit.config.sync_files_config import SyncFilesConfig
 from packit.config.notifications import (
@@ -139,3 +141,22 @@ class CommonPackageConfig:
             f"{self.dist_git_base_url}{self.dist_git_namespace}/"
             f"{self.downstream_package_name}.git"
         )
+
+    def get_all_files_to_sync(self):
+        """
+        Adds the default files (config file, spec file) to synced files when doing propose-update.
+        :return: SyncFilesConfig with default files
+        """
+        files = self.synced_files.files_to_sync
+
+        if self.specfile_path not in (item.src for item in files):
+            files.append(SyncFilesItem(src=self.specfile_path, dest=self.specfile_path))
+
+        if self.config_file_path and self.config_file_path not in (
+            item.src for item in files
+        ):
+            files.append(
+                SyncFilesItem(src=self.config_file_path, dest=self.config_file_path)
+            )
+
+        return SyncFilesConfig(files)

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -25,14 +25,14 @@ import logging
 from pathlib import Path
 from typing import Optional, List, Dict, Union
 
+from ogr.abstract import GitProject
 from yaml import safe_load
 
-from ogr.abstract import GitProject
 from packit.actions import ActionName
 from packit.config.common_package_config import CommonPackageConfig
 from packit.config.job_config import JobConfig, get_default_jobs, JobType
 from packit.config.notifications import NotificationsConfig
-from packit.config.sync_files_config import SyncFilesConfig, SyncFilesItem
+from packit.config.sync_files_config import SyncFilesConfig
 from packit.constants import CONFIG_FILE_NAMES
 from packit.exceptions import PackitConfigException
 
@@ -150,26 +150,11 @@ class PackageConfig(CommonPackageConfig):
         logger.debug(package_config)
         return package_config
 
-    def get_all_files_to_sync(self):
-        """
-        Adds the default files (config file, spec file) to synced files when doing propose-update.
-        :return: SyncFilesConfig with default files
-        """
-        files = self.synced_files.files_to_sync
-
-        if self.specfile_path not in (item.src for item in files):
-            files.append(SyncFilesItem(src=self.specfile_path, dest=self.specfile_path))
-
-        if self.config_file_path and self.config_file_path not in (
-            item.src for item in files
-        ):
-            files.append(
-                SyncFilesItem(src=self.config_file_path, dest=self.config_file_path)
-            )
-
-        return SyncFilesConfig(files)
-
     def get_copr_build_project_value(self) -> Optional[str]:
+        """
+        get copr project name from this first copr job
+        this is only used when invoking copr builds from CLI
+        """
         projects_list = [
             job.metadata.project
             for job in self.jobs

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -19,16 +19,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import cccolutils
-import git
 import logging
 import os
-import requests
 import tempfile
 from pathlib import Path
 from typing import Optional, Sequence, List
 
+import cccolutils
+import git
+import requests
 from ogr.abstract import PullRequest
+
 from packit.base_git import PackitRepositoryBase
 from packit.config import (
     Config,
@@ -36,6 +37,7 @@ from packit.config import (
     SyncFilesConfig,
     get_local_package_config,
 )
+from packit.config.common_package_config import CommonPackageConfig
 from packit.exceptions import PackitException, PackitConfigException
 from packit.fedpkg import FedPKG
 from packit.local_project import LocalProject
@@ -61,7 +63,7 @@ class DistGit(PackitRepositoryBase):
     def __init__(
         self,
         config: Config,
-        package_config: PackageConfig,
+        package_config: CommonPackageConfig,
         local_project: LocalProject = None,
     ):
         super().__init__(config=config, package_config=package_config)

--- a/packit/status.py
+++ b/packit/status.py
@@ -24,9 +24,10 @@ from datetime import datetime, timedelta
 from typing import List, Tuple, Dict, Set
 
 from koji import ClientSession, BUILD_STATES
-
 from ogr.abstract import Release
-from packit.config import Config, PackageConfig
+
+from packit.config import Config
+from packit.config.common_package_config import CommonPackageConfig
 from packit.copr_helper import CoprHelper
 from packit.distgit import DistGit
 from packit.exceptions import PackitException
@@ -43,7 +44,7 @@ class Status:
     def __init__(
         self,
         config: Config,
-        package_config: PackageConfig,
+        package_config: CommonPackageConfig,
         upstream: Upstream,
         distgit: DistGit,
     ):

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -33,7 +33,8 @@ from packaging import version
 from packit import utils
 from packit.actions import ActionName
 from packit.base_git import PackitRepositoryBase
-from packit.config import Config, PackageConfig, SyncFilesConfig
+from packit.config import Config, SyncFilesConfig
+from packit.config.common_package_config import CommonPackageConfig
 from packit.constants import SPEC_PACKAGE_SECTION, DEFAULT_ARCHIVE_EXT, DATETIME_FORMAT
 from packit.exceptions import (
     PackitException,
@@ -55,7 +56,10 @@ class Upstream(PackitRepositoryBase):
     """ interact with upstream project """
 
     def __init__(
-        self, config: Config, package_config: PackageConfig, local_project: LocalProject
+        self,
+        config: Config,
+        package_config: CommonPackageConfig,
+        local_project: LocalProject,
     ):
         """
         :param config: global configuration

--- a/tests/integration/test_get_api.py
+++ b/tests/integration/test_get_api.py
@@ -2,10 +2,12 @@ from pathlib import Path
 
 import pytest
 from flexmock import flexmock
+from packit.config.job_config import JobType, JobConfigTriggerType
 
 from packit.api import PackitAPI
 from packit.cli import utils
 from packit.cli.utils import get_packit_api
+from packit.config import JobConfig
 from packit.local_project import LocalProject
 from tests.spellbook import get_test_config, initiate_git_repo
 
@@ -152,6 +154,18 @@ def test_url_is_upstream():
                 upstream_project_url="https://github.com/packit-service/ogr",
                 dist_git_base_url="https://src.fedoraproject.org",
                 synced_files=None,
+            ),
+            True,
+        ),
+        (
+            [
+                ("remote", "https://some.remote/ur/l.git"),
+                ("origin", "git@github.com:user/ogr.git"),
+            ],
+            JobConfig(
+                type=JobType.build,
+                trigger=JobConfigTriggerType.pull_request,
+                upstream_project_url="https://github.com/packit-service/ogr",
             ),
             True,
         ),


### PR DESCRIPTION
* [x] fix tests
* [x] implement Hunor's suggestion

since we want JobConfig to be as powerful as PackageConfig, we need to
make sure that packit work with it via API

Follow-up to: #858
Needed for packit-service/packit-service#418

Signed-off-by: Tomas Tomecek <ttomecek@redhat.com>