### PR TITLE
Improve the message when marking issues as stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,15 +11,18 @@ exemptLabels:
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
-markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs.
+markComment: |
+  This issue has been marked as *stale* because it hasn't seen any
+  activity for the last 60 days.
 
-  Thank you for your contributions.
+  *Stale* issues are closed after 14 days, unless the label is removed
+  by a maintainer or someone comments on it.
 
-  We are doing this to be sure that the issue is still relevant.
-  Anyone can comment to remove the stale state.
-  (The issues marked with `pinned`, `security`, `bug` or `EPIC` label
-   are not considered stale.)
+  This is done in order to ensure that open issues are still relevant.
+
+  Thank you for your contribution! :unicorn: :rocket: :robot:
+
+  (Note: issues labeled with *pinned*, *security*, *bug* or *EPIC* are
+  never marked as stale.)
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false


### PR DESCRIPTION
Use literal style (|) in the YAML string, in order to keep new-lines and
have a better formatting.

Be explicit about the dates.

Be more English (hopefully).

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>