### PR TITLE
Log str(ex) when a RebaseHelperError is encountered

### DIFF
--- a/packit/specfile.py
+++ b/packit/specfile.py
@@ -80,7 +80,7 @@ class Specfile(SpecFile):
             self.update_changelog_in_spec(changelog_entry)
 
         except RebaseHelperError as ex:
-            logger.error(f"Rebase-helper failed to change the spec file: {ex!r}")
+            logger.error(f"Rebase-helper failed to change the spec file: {ex}")
             raise PackitException("Rebase-helper didn't do the job.")
 
     def write_spec_content(self):


### PR DESCRIPTION
Currently the representation of the RebaseHelperException is logged,
which results in log lines like:

```
ERROR    Rebase-helper failed to change the spec file: RebaseHelperError()
```

This is not helpful.

By removing `!r`, this log will use str(ex) instead which will print the
error message. See

https://github.com/rebase-helper/rebase-helper/blob/fb79efc2bc5590107ffe7e665ad469c58ce2a302/rebasehelper/exceptions.py#L43

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>