### PR TITLE
Remove 'jsonschema' as a dependency

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -14,7 +14,6 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-click-man
 BuildRequires:  python3-GitPython
 BuildRequires:  python3-gnupg
-BuildRequires:  python3-jsonschema
 BuildRequires:  python3-ogr
 BuildRequires:  python3-packaging
 BuildRequires:  python3-pyyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ install_requires =
     cccolutils
     click
     copr
-    jsonschema
     lazy_object_proxy
     marshmallow
     marshmallow-enum


### PR DESCRIPTION
Marshmallow is used instead for some time now.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>