### PR TITLE
[packit] Copr enhancements

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -33,9 +33,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Sequence, Callable, List, Tuple, Dict, Iterable, Optional
 
-from ogr.abstract import PullRequest
 from tabulate import tabulate
 
+from ogr.abstract import PullRequest
 from packit import utils
 from packit.actions import ActionName
 from packit.config import Config
@@ -650,6 +650,10 @@ class PackitAPI:
         description: str = None,
         instructions: str = None,
         upstream_ref: str = None,
+        list_on_homepage: bool = False,
+        preserve_project: bool = False,
+        additional_packages: List[str] = None,
+        additional_repos: List[str] = None,
     ) -> Tuple[int, str]:
         """
         Submit a build to copr build system using an SRPM using the current checkout.
@@ -661,6 +665,10 @@ class PackitAPI:
         :param description: description of the project
         :param instructions: installation instructions for the project
         :param upstream_ref: git ref to upstream commit
+        :param list_on_homepage: if set, created copr project will be visible on copr's home-page
+        :param preserve_project: if set, project will not be created as temporary
+        :param list additional_packages: buildroot packages for the chroot [DOES NOT WORK YET]
+        :param list additional_repos: buildroot additional additional_repos
         :return: id of the created build and url to the build web page
         """
         srpm_path = self.create_srpm(
@@ -679,6 +687,10 @@ class PackitAPI:
             owner=owner,
             description=description,
             instructions=instructions,
+            list_on_homepage=list_on_homepage,
+            preserve_project=preserve_project,
+            additional_packages=additional_packages,
+            additional_repos=additional_repos,
         )
         logger.debug(
             f"Submitting a build to copr build system,"

--- a/packit/cli/copr_build.py
+++ b/packit/cli/copr_build.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 import logging
 import os
+from typing import Optional, List
 
 import click
 
@@ -58,6 +59,27 @@ logger = logging.getLogger(__name__)
     default=None,
 )
 @click.option(
+    "--list-on-homepage",
+    help="Created copr project will be visible on copr's home-page.",
+    default=False,
+    is_flag=True,
+)
+@click.option(
+    "--preserve-project",
+    help="Created copr project will not be removed after 60 days.",
+    default=False,
+    is_flag=True,
+)
+@click.option(
+    "--additional-repos",
+    help="URLs to additional yum repos, which can be used during build. "
+    "Comma separated. "
+    "This should be baseurl from .repo file. "
+    "E.g.: http://copr-be.cloud.fedoraproject.org/"
+    "results/rhughes/f20-gnome-3-12/fedora-$releasever-$basearch/",
+    default=None,
+)
+@click.option(
     "--upstream-ref",
     default=None,
     help="Git ref of the last upstream commit in the current branch "
@@ -75,7 +97,10 @@ def copr_build(
     targets,
     description,
     instructions,
+    list_on_homepage,
+    preserve_project,
     upstream_ref,
+    additional_repos,
     path_or_url,
 ):
     """
@@ -96,6 +121,10 @@ def copr_build(
         *targets.split(","), default="fedora-rawhide-x86_64"
     )
 
+    additional_repos_list: Optional[List[str]] = additional_repos.split(
+        ","
+    ) if additional_repos else None
+
     build_id, repo_url = api.run_copr_build(
         project=project,
         chroots=list(targets_to_build),
@@ -103,6 +132,9 @@ def copr_build(
         description=description,
         instructions=instructions,
         upstream_ref=upstream_ref,
+        list_on_homepage=list_on_homepage,
+        preserve_project=preserve_project,
+        additional_repos=additional_repos_list,
     )
     click.echo(f"Build id: {build_id}, repo url: {repo_url}")
     if not nowait:

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -66,6 +66,10 @@ class JobMetadataConfig:
         dist_git_branches: List[str] = None,
         branch: str = None,
         scratch: bool = False,
+        list_on_homepage: bool = False,
+        preserve_project: bool = False,
+        additional_packages: List[str] = None,
+        additional_repos: List[str] = None,
     ):
         """
         :param targets: copr_build job, mock chroots where to build
@@ -75,6 +79,10 @@ class JobMetadataConfig:
         :param dist_git_branches: propose_downstream, branches in dist-git where packit should work
         :param branch: for `commit` trigger to specify the branch name
         :param scratch: if we want to run scratch build in koji
+        :param list_on_homepage: if set, created copr project will be visible on copr's home-page
+        :param preserve_project: if set, project will not be created as temporary
+        :param list additional_packages: buildroot packages for the chroot [DOES NOT WORK YET]
+        :param list additional_repos: buildroot additional additional_repos
         """
         self.targets: Set[str] = set(targets) if targets else set()
         self.timeout: int = timeout
@@ -85,6 +93,10 @@ class JobMetadataConfig:
         ) if dist_git_branches else set()
         self.branch: str = branch
         self.scratch: bool = scratch
+        self.list_on_homepage: bool = list_on_homepage
+        self.preserve_project: bool = preserve_project
+        self.additional_packages: List[str] = additional_packages or []
+        self.additional_repos: List[str] = additional_repos or []
 
     def __repr__(self):
         return (
@@ -93,9 +105,13 @@ class JobMetadataConfig:
             f"timeout={self.timeout}, "
             f"owner={self.owner}, "
             f"project={self.project}, "
-            f"dist_git_branches={self.dist_git_branches},"
-            f"branch={self.branch},"
-            f"scratch={self.scratch})"
+            f"dist_git_branches={self.dist_git_branches}, "
+            f"branch={self.branch}, "
+            f"scratch={self.scratch}, "
+            f"list_on_homepage={self.list_on_homepage}, "
+            f"preserve_project={self.preserve_project}, "
+            f"additional_packages={self.additional_packages}, "
+            f"additional_repos={self.additional_repos})"
         )
 
     def __eq__(self, other: object):
@@ -111,6 +127,10 @@ class JobMetadataConfig:
             and self.dist_git_branches == other.dist_git_branches
             and self.branch == other.branch
             and self.scratch == other.scratch
+            and self.list_on_homepage == other.list_on_homepage
+            and self.preserve_project == other.preserve_project
+            and self.additional_packages == other.additional_packages
+            and self.additional_repos == other.additional_repos
         )
 
 

--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -49,6 +49,7 @@ class CoprHelper:
         preserve_project: bool = False,
         additional_packages: List[str] = None,
         additional_repos: List[str] = None,
+        update_additional_values: bool = True,
     ) -> None:
         """
         Create a project in copr if it does not exists.
@@ -65,17 +66,26 @@ class CoprHelper:
                 logger.info(f"Updating copr project '{owner}/{project}'")
                 logger.debug(f"old targets = {set(copr_proj.chroot_repos.keys())}")
                 logger.debug(f"new targets = {set(chroots)}")
+
+                if not update_additional_values:
+                    delete_after_days = None
+                elif preserve_project:
+                    delete_after_days = -1
+                else:
+                    delete_after_days = 60
+
                 self.copr_client.project_proxy.edit(
                     ownername=owner,
                     projectname=project,
                     chroots=chroots,
                     description=description,
                     instructions=instructions,
-                    unlisted_on_hp=not list_on_homepage,
+                    unlisted_on_hp=not list_on_homepage
+                    if update_additional_values
+                    else None,
                     additional_repos=additional_repos,
-                    delete_after_days=60 if not preserve_project else None,
+                    delete_after_days=delete_after_days,
                 )
-                # TODO: disable removal when temporary=False
                 # TODO: additional_packages
         except CoprNoResultException as ex:
             if owner != self.configured_owner:

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -228,6 +228,10 @@ class JobMetadataSchema(MM23Schema):
     dist_git_branches = fields.List(fields.String())
     branch = fields.String()
     scratch = fields.Boolean()
+    list_on_homepage = fields.Boolean()
+    preserve_project = fields.Boolean()
+    additional_packages = fields.List(fields.String())
+    additional_repos = fields.List(fields.String())
 
     @pre_load
     def ordered_preprocess(self, data, **_):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -38,8 +38,10 @@ from packit.config.job_config import JobMetadataConfig
 from packit.schema import JobConfigSchema
 
 
-def get_job_config_dict_simple():
-    return {"job": "build", "trigger": "release"}
+def get_job_config_dict_simple(**update):
+    result = {"job": "build", "trigger": "release"}
+    result.update(update)
+    return result
 
 
 def get_job_config_simple(**kwargs):
@@ -151,6 +153,18 @@ def test_job_config_validate(raw, is_valid):
     [
         (get_job_config_dict_simple(), get_job_config_simple()),
         (get_job_config_dict_full(), get_job_config_full()),
+        (
+            get_job_config_dict_simple(),
+            get_job_config_simple(metadata=JobMetadataConfig(preserve_project=False)),
+        ),
+        (
+            get_job_config_dict_simple(metadata={"preserve_project": False}),
+            get_job_config_simple(metadata=JobMetadataConfig(preserve_project=False)),
+        ),
+        (
+            get_job_config_dict_simple(metadata={"preserve_project": True}),
+            get_job_config_simple(metadata=JobMetadataConfig(preserve_project=True)),
+        ),
     ],
 )
 def test_job_config_parse(raw, expected_config):


### PR DESCRIPTION
- Be able to set listed_on_hp,preserve_project,additional_repos in CLI for copr-build.
- Allow setting/editing of unlisted_on_hp,temporary,additional_repos for copr projects.
- Add new fields for metadata about copr-builds.
- Fixes: https://github.com/packit-service/packit/issues/774
- Users can set also `additional_packages` in config but it's not used yet. (Needs to be set per-chroot and will take more time to make it properly.)
- [x] PR in packit-service with proper tests will follow.