### PR TITLE
package_config: set defaults correctly to all jobs

### DIFF
--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -129,23 +129,25 @@ class PackageConfig(CommonPackageConfig):
         if config_file_path and not raw_dict.get("config_file_path", None):
             raw_dict.update(config_file_path=config_file_path)
 
+        # we need to process defaults first so they get propagated to JobConfigs
+
         if "jobs" not in raw_dict:
             # we want default jobs to go through the proper parsing process
             raw_dict["jobs"] = get_default_jobs()
 
-        package_config = PackageConfigSchema().load_config(raw_dict)
-
-        if not getattr(package_config, "specfile_path", None):
+        if not raw_dict.get("specfile_path", None):
             if spec_file_path:
-                package_config.specfile_path = spec_file_path
+                raw_dict["specfile_path"] = spec_file_path
             else:
                 raise PackitConfigException("Spec file was not found!")
 
-        if not getattr(package_config, "upstream_package_name", None) and repo_name:
-            package_config.upstream_package_name = repo_name
+        if not raw_dict.get("upstream_package_name", None) and repo_name:
+            raw_dict["upstream_package_name"] = repo_name
 
-        if not getattr(package_config, "downstream_package_name", None) and repo_name:
-            package_config.downstream_package_name = repo_name
+        if not raw_dict.get("downstream_package_name", None) and repo_name:
+            raw_dict["downstream_package_name"] = repo_name
+
+        package_config = PackageConfigSchema().load_config(raw_dict)
 
         logger.debug(package_config)
         return package_config

--- a/packit/config/package_config_validator.py
+++ b/packit/config/package_config_validator.py
@@ -24,7 +24,7 @@ from typing import Dict, Union
 
 from marshmallow import ValidationError
 
-from packit.config.package_config import PackageConfig
+from packit.config.package_config import PackageConfig, get_local_specfile_path
 from packit.exceptions import PackitConfigException
 
 
@@ -40,7 +40,11 @@ class PackageConfigValidator:
         schema_errors = None
         try:
             PackageConfig.get_from_dict(
-                self.content, config_file_path=str(self.config_file_path)
+                self.content,
+                config_file_path=str(self.config_file_path),
+                spec_file_path=str(
+                    get_local_specfile_path(self.config_file_path.parent)
+                ),
             )
         except ValidationError as e:
             schema_errors = e.messages

--- a/tests/integration/test_validate_config.py
+++ b/tests/integration/test_validate_config.py
@@ -23,7 +23,6 @@ from pathlib import Path
 import pytest
 
 from packit.api import PackitAPI
-from packit.config.config import Config
 from packit.utils import cwd
 
 
@@ -72,7 +71,7 @@ from packit.utils import cwd
             "** field pull_request has an incorrect value:\n"
             "*** value at index successful_build: Not a valid boolean.",
         ),
-        ("{}", "Spec file was not found!"),
+        ("{}", "packit.json is valid and ready to be used"),
         (
             """
             {
@@ -255,9 +254,8 @@ from packit.utils import cwd
 )
 def test_schema_validation(tmpdir, raw_package_config, expected_output):
     with cwd(tmpdir):
-        with open("packit.json", "w") as package_config_file:
-            package_config_file.writelines(raw_package_config)
+        Path("packit.json").write_text(raw_package_config)
+        Path("packit.spec").write_text("hello")
 
-        api = PackitAPI(Config(), None)
-        output = api.validate_package_config(Path("."))
+        output = PackitAPI.validate_package_config(Path("."))
         assert expected_output in output


### PR DESCRIPTION
Fixes https://github.com/packit-service/packit-service/issues/714

configs are easy, right o_O  

So... Before this change, we first created PackageConfig (and copied all
attribs to all jobs) and then set all the defaults globally to that
PackageConfig instance -- obviously that doesn't work for the jobs, so
they didn't inherit the defaults.

With this change, we set the defaults in the raw_dict before creating
PackageConfig, hence defaults get processed correctly and set to all
jobs.

🍺
