### PR TITLE
[patch metadata] ignore option and instance creation improvement

### DIFF
--- a/packit/patches.py
+++ b/packit/patches.py
@@ -104,35 +104,34 @@ class PatchMetadata:
 
         return msg
 
-    def rename(self, new_name: str):
-        new_path = self.path.parent / new_name
-        logger.debug(f"Renaming the patch: {self.name} -> {new_path}")
-        self.path.rename(new_path)
-        self.path = new_path
-        self.name = new_name
-
-    def update_metadata_from_commit(self):
-        metadata = get_metadata_from_message(self.commit)
-        if not metadata:
+    @staticmethod
+    def from_commit(commit: git.Commit, patch_path: Path):
+        metadata = get_metadata_from_message(commit) or {}
+        if metadata:
             logger.debug(
-                f"Commit {self.commit.hexsha:.8} does not contain any metadata."
+                f"Commit {commit.hexsha:.8} metadata:\n"
+                f"{yaml.dump(metadata, indent=4)}"
             )
-            return
+        else:
+            logger.debug(f"Commit {commit.hexsha:.8} does not contain any metadata.")
 
-        logger.debug(
-            f"Commit {self.commit.hexsha:.8} metadata:\n"
-            f"{yaml.dump(metadata, indent=4)}"
-        )
+        name = metadata.get("patch_name")
+        if name:
+            new_path = patch_path.parent / name
+            logger.debug(f"Renaming the patch: {patch_path.name} -> {new_path}")
+            patch_path.rename(new_path)
+            patch_path = new_path
+        else:
+            name = patch_path.name
 
-        if "patch_name" in metadata:
-            self.rename(metadata["patch_name"])
-
-        self.description = metadata.get("description") or self.description
-        self.present_in_specfile = (
-            metadata.get("present_in_specfile") or self.present_in_specfile
-        )
-        self.location_in_specfile = (
-            metadata.get("location_in_specfile") or self.location_in_specfile
+        return PatchMetadata(
+            name=name,
+            path=patch_path,
+            description=metadata.get("description"),
+            present_in_specfile=metadata.get("present_in_specfile"),
+            location_in_specfile=metadata.get("location_in_specfile"),
+            ignore=metadata.get("ignore"),
+            commit=commit,
         )
 
 
@@ -279,10 +278,9 @@ class PatchGenerator:
                         # so some commits won't be covered by a dedicated patch file
                         if commit.hexsha in patch_content:
                             path = Path(patch_name)
-                            patch_metadata = PatchMetadata(
-                                commit=commit, path=path, name=path.name,
+                            patch_metadata = PatchMetadata.from_commit(
+                                commit=commit, patch_path=path
                             )
-                            patch_metadata.update_metadata_from_commit()
 
                             if patch_metadata.ignore:
                                 logger.debug(

--- a/tests/integration/test_source_git.py
+++ b/tests/integration/test_source_git.py
@@ -296,6 +296,53 @@ def test_basic_local_update_patch_content_with_metadata(
     assert patches in git_diff
 
 
+def test_basic_local_update_patch_content_with_metadata_and_patch_ignored(
+    sourcegit_and_remote,
+    distgit_and_remote,
+    mock_remote_functionality_sourcegit,
+    api_instance_source_git,
+):
+    """ propose-update for sourcegit test: mock remote API, use local upstream and dist-git """
+
+    sourcegit, _ = sourcegit_and_remote
+    distgit, _ = distgit_and_remote
+    mock_spec_download_remote_s(distgit)
+
+    create_merge_commit_in_source_git(sourcegit)
+
+    source_file = sourcegit / "big-source-file.txt"
+    source_file.write_text("new changes")
+    git_add_and_commit(
+        directory=sourcegit, message="source change\nignore: true",
+    )
+
+    source_file = sourcegit / "ignored_file.txt"
+    source_file.write_text(" And I am sad.")
+    git_add_and_commit(directory=sourcegit, message="make a file sad")
+
+    api_instance_source_git.sync_release("master", "0.1.0", upstream_ref="0.1.0")
+
+    git_diff = subprocess.check_output(
+        ["git", "diff", "HEAD~", "HEAD"], cwd=distgit
+    ).decode()
+
+    patches = """
++# PATCHES FROM SOURCE GIT:
++
++# switching to amarillo hops
++# Author: Packit Test Suite <test@example.com>
++Patch0001: 0001-switching-to-amarillo-hops.patch
++
++# actually, let's do citra
++# Author: Packit Test Suite <test@example.com>
++Patch0002: 0002-actually-let-s-do-citra.patch
++
++
+ %description
+"""
+    assert patches in git_diff
+
+
 def test_basic_local_update_patch_content_with_downstream_patch(
     sourcegit_and_remote,
     distgit_and_remote,


### PR DESCRIPTION
- Simplify creating of the PatchMetadata instance.
- Add ignore option to patch metadata.
- Follow-up to #875 