### PR TITLE
local_project: check out PR over ref

### DIFF
--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -120,10 +120,13 @@ class LocalProject:
         if refresh:
             self.refresh_the_arguments()
 
-        if ref:
-            self.checkout_ref(ref)
+        # p-s gives us both, commit hash for a PR and PR ID as well
+        # since we want to have 'pr123' in the release field, let's check out
+        # the PR itself, so if both are specified, PR ID > ref
         if pr_id:
             self.checkout_pr(pr_id)
+        elif ref:
+            self.checkout_ref(ref)
 
     def __repr__(self):
         return (

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -448,7 +448,9 @@ class Upstream(PackitRepositoryBase):
             "*",
         ]
         try:
-            git_des_out = run_command(git_des_command, output=True).strip()
+            git_des_out = run_command(
+                git_des_command, output=True, cwd=self.local_project.working_dir
+            ).strip()
         except PackitCommandFailedError as ex:
             # probably no tags in the git repo
             logger.info(f"Exception while describing the repository: {ex!r}")

--- a/tests/functional/test_validate_config.py
+++ b/tests/functional/test_validate_config.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2019 Red Hat, Inc.
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,38 +21,15 @@
 # SOFTWARE.
 
 """
-Validate PackageConfig
+Functional tests the validate-config command
 """
 
-import logging
-import os
-from pathlib import Path
-
-import click
-from packit.local_project import LocalProject
-
-from packit.api import PackitAPI
-from packit.cli.types import LocalProjectParameter
-from packit.cli.utils import cover_packit_exception
-from packit.config import get_context_settings
-
-logger = logging.getLogger(__name__)
+from packit.utils import cwd
+from tests.functional.spellbook import call_real_packit
 
 
-@click.command("validate-config", context_settings=get_context_settings())
-@click.argument("path_or_url", type=LocalProjectParameter(), default=os.path.curdir)
-@cover_packit_exception
-def validate_config(path_or_url: LocalProject):
-    """
-    Validate PackageConfig validation.
-
-    \b
-    - checks missing values
-    - checks incorrect types
-
-    PATH_OR_URL argument is a local path or a URL to a git repository with packit configuration file
-    """
-    # we use PackageConfig.load_from_dict for the validation, hence we don't parse it here
-    output = PackitAPI.validate_package_config(Path(path_or_url.working_dir))
-    logger.info(output)
-    # TODO: print more if config.debug
+def test_srpm_command_for_path(upstream_or_distgit_path, tmp_path):
+    with cwd(tmp_path):
+        call_real_packit(
+            parameters=["--debug", "validate-config", str(upstream_or_distgit_path)]
+        )

--- a/tests/unit/test_local_project.py
+++ b/tests/unit/test_local_project.py
@@ -19,14 +19,16 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
+import subprocess
 import tempfile
+from pathlib import Path
 
 import git
 from flexmock import flexmock
 
 from packit import local_project, utils
 from packit.local_project import LocalProject
+from tests.spellbook import initiate_git_repo
 
 
 def test_parse_repo_name_and_namespace_from_namespace():
@@ -356,6 +358,41 @@ def test_working_dir():
     assert project.working_dir == "./local/directory/to/git"
     assert project.git_repo
     assert project.ref == "branch"
+
+
+def test_pr_id_and_ref(tmp_path: Path):
+    """ p-s passes both ref and pr_id, we want to check out PR """
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    subprocess.check_call(["git", "init", "--bare", "."], cwd=remote)
+    upstream_git = tmp_path / "upstream_git"
+    upstream_git.mkdir()
+    initiate_git_repo(upstream_git, push=True, upstream_remote=str(remote))
+    # mimic github PR
+    pr_id = "123"
+    ref = (
+        subprocess.check_output(["git", "rev-parse", "HEAD^"], cwd=upstream_git)
+        .strip()
+        .decode()
+    )
+    local_tmp_branch = "asdqwe"
+    subprocess.check_call(["git", "branch", local_tmp_branch, ref], cwd=upstream_git)
+    subprocess.check_call(
+        ["git", "push", "origin", f"{local_tmp_branch}:refs/pull/{pr_id}/head"],
+        cwd=upstream_git,
+    )
+    subprocess.check_call(["git", "branch", "-D", local_tmp_branch], cwd=upstream_git)
+
+    LocalProject(working_dir=str(upstream_git), offline=True, pr_id=pr_id, ref=ref)
+
+    assert (
+        subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=upstream_git
+        )
+        .strip()
+        .decode()
+        == f"pr/{pr_id}"
+    )
 
 
 # OFFLINE


### PR DESCRIPTION
p-s gives us both, commit hash for a PR and PR ID as well
since we want to have 'pr123' in the release field, let's check out
the PR itself, so if both are specified, PR ID > ref

I deserve a Nobel prize for that test case!

Fixes #890