### PR TITLE
Use a Path-type argument when calling config validation

### DIFF
--- a/packit/cli/validate_config.py
+++ b/packit/cli/validate_config.py
@@ -26,12 +26,12 @@ Validate PackageConfig
 
 import logging
 import os
+from pathlib import Path
 
 import click
 
 from packit.api import PackitAPI
 from packit.cli.types import LocalProjectParameter
-from packit.cli.utils import cover_packit_exception
 from packit.config import get_context_settings
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,6 @@ logger = logging.getLogger(__name__)
 
 @click.command("validate-config", context_settings=get_context_settings())
 @click.argument("path_or_url", type=LocalProjectParameter(), default=os.path.curdir)
-@cover_packit_exception
 def validate_config(path_or_url):
     """
     Validate PackageConfig validation.
@@ -51,6 +50,6 @@ def validate_config(path_or_url):
     PATH_OR_URL argument is a local path or a URL to a git repository with packit configuration file
     """
     # we use PackageConfig.load_from_dict for the validation, hence we don't parse it here
-    output = PackitAPI.validate_package_config(path_or_url)
+    output = PackitAPI.validate_package_config(Path(path_or_url.working_dir))
     logger.info(output)
     # TODO: print more if config.debug


### PR DESCRIPTION
PackitAPI.validate_package_cofig() expects a Path argument, but
cli.validate_config() has path_or_url as LocalProject.

Fix this by creating a Path from path_or_url.working_dir.

Probably naming and types should be adjusted in this area of code to
improve readability.

Furthermore: remove covering up exceptions. There is no point in asking
users to report errors if they cannot provide us the full traceback and
we only make finding issues like this one more difficult.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>