### PR TITLE
Update packit.spec and setup.cfg files 

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -24,6 +24,8 @@ BuildRequires:  python3-koji
 BuildRequires:  python3-lazy-object-proxy
 BuildRequires:  python3-marshmallow
 BuildRequires:  python3-marshmallow-enum
+BuildRequires:  python3-munch
+BuildRequires:  python3-requests
 BuildRequires:  rebase-helper
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(setuptools-scm)

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ keywords =
 packages = find:
 install_requires =
     GitPython
-    PyGithub
     PyYAML
     cccolutils
     click


### PR DESCRIPTION
New dependencies added to packit.spec file to be able to handle
dependencies in packit-service easier.

Pcakage pygithub was removed from setup.cfg,
as it was not used anywhere in code.