### PR TITLE
[setup.cfg] bodhi-client can now be installed from PyPI

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -21,6 +21,7 @@ BuildRequires:  python3-tabulate
 BuildRequires:  python3-cccolutils
 BuildRequires:  python3-copr
 BuildRequires:  python3-koji
+BuildRequires:  python3-bodhi-client
 BuildRequires:  python3-lazy-object-proxy
 BuildRequires:  python3-marshmallow
 BuildRequires:  python3-marshmallow-enum
@@ -44,7 +45,6 @@ projects into Fedora operating system.
 Summary:        %{summary}
 # See setup.cfg for details
 Requires:       python3-koji
-Requires:       python3-bodhi-client
 %{?python_provide:%python_provide python3-%{real_name}}
 
 %description -n python3-%{real_name}

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,9 +47,7 @@ install_requires =
     rebasehelper
     requests
     tabulate
-    # We can't install bodhi-client from PyPI
-    # https://github.com/fedora-infra/bodhi/issues/3058
-    # bodhi-client
+    bodhi-client
     # Packit installed from rpm pulls in python3-koji as dependency, but
     # Python's pkg_resources doesn't recognize it, because it doesn't have egg-info.
     # Consequently packit fails with:


### PR DESCRIPTION
https://github.com/fedora-infra/bodhi/pull/4081