### PR TITLE
Revert "Drop python 3.6"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3.6
   - repo: https://github.com/prettier/prettier
     rev: 2.0.5
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Topic :: Software Development
@@ -56,7 +57,7 @@ install_requires =
     # It was supposed to be fixed with https://bugzilla.redhat.com/show_bug.cgi?id=1750391
     # but the real culprit is https://pagure.io/koji/issue/912
     # koji
-python_requires = >=3.7
+python_requires = >=3.6
 include_package_data = True
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
This reverts commit 88576b8cd4eb62178626f2ee30b53cb03e5d8765.

In Centos 8 Python 3.6 is the default python3. Having Python 3.6 support
will make life easier there.