### PR TITLE
[packit.spec] remove not needed BuildRequires

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -21,12 +21,9 @@ BuildRequires:  python3-tabulate
 BuildRequires:  python3-cccolutils
 BuildRequires:  python3-copr
 BuildRequires:  python3-koji
-BuildRequires:  python3-bodhi-client
 BuildRequires:  python3-lazy-object-proxy
 BuildRequires:  python3-marshmallow
 BuildRequires:  python3-marshmallow-enum
-BuildRequires:  python3-munch
-BuildRequires:  python3-requests
 BuildRequires:  rebase-helper
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(setuptools-scm)


### PR DESCRIPTION
They were added because of https://github.com/packit-service/packit-service/pull/717 but are not needed anymore (since we use setupcfg2rpm.py).