### PR TITLE
Revert "[.packit.yaml] remove 'sh -c' from create-archive"

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,7 +9,7 @@ upstream_project_url: https://github.com/packit-service/packit
 actions:
   create-archive:
     - "python3 setup.py sdist --dist-dir ."
-    - "echo packitos-$(python3 setup.py --version).tar.gz"
+    - "sh -c 'echo packitos-$(python3 setup.py --version).tar.gz'"
   get-current-version:
     - "python3 setup.py --version"
 


### PR DESCRIPTION
This reverts b2f9d54a until we figure out why
https://github.com/packit-service/sandcastle/pull/65
does not work (is not deployed/used?).