### PR TITLE
Support closing bugzillas from create-update

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -598,14 +598,17 @@ class PackitAPI:
         update_type: str,
         update_notes: str,
         koji_builds: Sequence[str] = None,
+        bugzilla_ids: Optional[List[int]] = None,
     ):
         """
-        Create bodhi update
+        Create bodhi update.
 
-        :param dist_git_branch: git ref
-        :param update_type: type of the update, check CLI
-        :param update_notes: documentation about the update
-        :param koji_builds: list of koji builds or None (and pick latest)
+        Args:
+            dist_git_branch: Git reference.
+            update_type: Type of the update, check CLI.
+            update_notes: Notes about the update to be displayed in Bodhi.
+            koji_builds: List of Koji builds or `None` (picks latest).
+            bugzilla_ids: List of Bugzillas that are resolved with the update.
         """
         logger.debug(
             f"Create bodhi update, "
@@ -616,6 +619,7 @@ class PackitAPI:
             dist_git_branch=dist_git_branch,
             update_notes=update_notes,
             update_type=update_type,
+            bugzilla_ids=bugzilla_ids,
         )
 
     def create_srpm(

--- a/packit/cli/create_update.py
+++ b/packit/cli/create_update.py
@@ -34,6 +34,25 @@ from packit.constants import DEFAULT_BODHI_NOTE
 logger = logging.getLogger(__name__)
 
 
+class BugzillaIDs(click.ParamType):
+    name = "bugzilla_ids"
+
+    def convert(self, value, param, ctx):
+        ids = []
+
+        str_ids = value.split(",")
+        for bugzilla_id in str_ids:
+            try:
+                ids.append(int(bugzilla_id))
+            except ValueError:
+                raise click.BadParameter(
+                    "cannot parse non-integer bugzilla ID. Please use following "
+                    "format: id[,id]"
+                )
+
+        return ids
+
+
 @click.command("create-update", context_settings=get_context_settings())
 @click.option(
     "--dist-git-branch",
@@ -61,11 +80,25 @@ logger = logging.getLogger(__name__)
     required=False,
     default="enhancement",
 )
+@click.option(
+    "-b",
+    "--resolve-bugzillas",
+    help="Bugzilla IDs that are resolved with the update",
+    required=False,
+    default=None,
+    type=BugzillaIDs(),
+)
 @click.argument("path_or_url", type=LocalProjectParameter(), default=os.path.curdir)
 @pass_config
 @cover_packit_exception
 def create_update(
-    config, dist_git_branch, koji_build, update_notes, update_type, path_or_url
+    config,
+    dist_git_branch,
+    koji_build,
+    update_notes,
+    update_type,
+    resolve_bugzillas,
+    path_or_url,
 ):
     """
     Create a bodhi update for the selected upstream project
@@ -92,4 +125,5 @@ def create_update(
             dist_git_branch=branch,
             update_notes=update_notes,
             update_type=update_type,
+            bugzilla_ids=resolve_bugzillas,
         )

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -410,6 +410,7 @@ class DistGit(PackitRepositoryBase):
         update_type: str,
         update_notes: str,
         koji_builds: Sequence[str] = None,
+        bugzilla_ids: Optional[List[int]] = None,
     ):
         logger.debug(
             f"About to create a Bodhi update of type {update_type!r} from {dist_git_branch!r}"
@@ -447,7 +448,16 @@ class DistGit(PackitRepositoryBase):
         # but in the end it's likely a waste of resources since bodhi will tell us
         rendered_note = update_notes.format(version=self.specfile.get_version())
         try:
-            result = b.save(builds=koji_builds, notes=rendered_note, type=update_type)
+            save_kwargs = {
+                "builds": koji_builds,
+                "notes": rendered_note,
+                "type": update_type,
+            }
+
+            if bugzilla_ids:
+                save_kwargs["bugs"] = list(map(str, bugzilla_ids))
+
+            result = b.save(**save_kwargs)
             logger.debug(f"Bodhi response:\n{result}")
             logger.info(
                 f"Bodhi update {result['alias']}:\n"


### PR DESCRIPTION
Add an option that can be used multiple times to specify Bugzilla IDs
that are being closed by the update.

TODO:

- [x] how to test this? Documentation for Bodhi ain't very helpful, the format in which they accept `bugs` is just guessed cause it's similar to koji builds…

Fixes #1382

---

<!-- release notes for changelog/blog follow -->

We have added a new option to Packit CLI when creating Bodhi updates, you can use `-b` or `--resolve-bugzillas` and specify IDs (separated by comma, e.g. `-b 1` or `-b 1,2,3`) of bugzillas that are being closed by the update.