### PR TITLE
Fix another test case on rawhide where pyyaml's version is utilized

### DIFF
--- a/tests/integration/test_source_git_init.py
+++ b/tests/integration/test_source_git_init.py
@@ -162,7 +162,8 @@ def test_create_from_upstream_no_patch(hello_source_git_repo, hello_dist_git_rep
 
 
 @pytest.mark.skipif(
-    list(map(int, yaml.__version__.split("."))) < [5, 1],
+    # on rawhide the version can contain letters:
+    list(map(int, yaml.__version__[:3].split("."))) < [5, 1],
     reason="Requires PyYAML 5.1 or higher.",
 )
 def test_create_from_upstream_with_patch(hello_source_git_repo, hello_dist_git_repo):


### PR DESCRIPTION
because it can contain letters which cannot be turned to int()

the same as
https://github.com/packit/packit/pull/1384/commits/ecdecbc742269d7cf9fffccd7fd0c54044d9c741

Fixes #1389

---

N/A - testing