### PR TITLE
Allow customization of release for SRPM

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -631,6 +631,8 @@ class PackitAPI:
         output_file: str = None,
         upstream_ref: str = None,
         srpm_dir: Union[Path, str] = None,
+        bump_version: bool = True,
+        release_suffix: Optional[str] = None,
     ) -> Path:
         """
         Create srpm from the upstream repo
@@ -644,7 +646,11 @@ class PackitAPI:
             self.up.run_action(actions=ActionName.post_upstream_clone)
 
             try:
-                self.up.prepare_upstream_for_srpm_creation(upstream_ref=upstream_ref)
+                self.up.prepare_upstream_for_srpm_creation(
+                    upstream_ref=upstream_ref,
+                    bump_version=bump_version,
+                    local_version=release_suffix,
+                )
             except Exception as ex:
                 raise PackitSRPMException(
                     f"Preparation of the repository for creation of an SRPM failed: {ex}"

--- a/packit/cli/srpm.py
+++ b/packit/cli/srpm.py
@@ -43,6 +43,18 @@ logger = logging.getLogger("packit")
     "from which packit should generate patches "
     "(this option implies the repository is source-git).",
 )
+@click.option(
+    "--bump/--no-bump",
+    default=True,
+    help="Specifies whether to bump version or not.",
+)
+@click.option(
+    "--release-suffix",
+    default=None,
+    type=click.STRING,
+    help="Specifies release suffix. Allows to override default generated:"
+    "{current_time}.{sanitized_current_branch}{git_desc_suffix}",
+)
 @click.argument(
     "path_or_url",
     type=LocalProjectParameter(),
@@ -55,6 +67,8 @@ def srpm(
     output,
     path_or_url,
     upstream_ref,
+    bump,
+    release_suffix,
 ):
     """
     Create new SRPM (.src.rpm file) using content of the upstream repository.
@@ -63,5 +77,10 @@ def srpm(
     it defaults to the current working directory
     """
     api = get_packit_api(config=config, local_project=path_or_url)
-    srpm_path = api.create_srpm(output_file=output, upstream_ref=upstream_ref)
+    srpm_path = api.create_srpm(
+        output_file=output,
+        upstream_ref=upstream_ref,
+        bump_version=bump,
+        release_suffix=release_suffix,
+    )
     logger.info(f"SRPM: {srpm_path}")


### PR DESCRIPTION
Signed-off-by: Matej Focko <mfocko@redhat.com>

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Related to #1181

---

<!-- release notes for changelog/blog follow -->

We have introduced new options for generating SRPM packages:
- `--no-bump` that prevents changing of the release in the SRPM, which can be used for creating SRPMs on checked out tags/releases.
- `--release-suffix` that allows you to customize the suffix after the release number, e.g. reference bugzilla or specific branch of the build.