### PR TITLE
Always assume downstream specfile is at the root

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -5,6 +5,7 @@
 Common package config attributes so they can be imported both in PackageConfig and JobConfig
 """
 from os import getenv
+from os.path import basename
 from typing import Dict, List, Optional, Union
 
 from packit.actions import ActionName
@@ -136,7 +137,7 @@ class CommonPackageConfig:
         downstream_specfile_path = (
             f"{self.downstream_package_name}.spec"
             if self.downstream_package_name
-            else self.specfile_path
+            else basename(upstream_specfile_path)
         )
         return SyncFilesItem(
             src=[

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -1236,6 +1236,19 @@ def test_get_specfile_sync_files_item():
     )
 
 
+def test_get_specfile_sync_files_nodownstreamname_item():
+    pc = PackageConfig(specfile_path="fedora/python-ogr.spec")
+    upstream_specfile_path = "fedora/python-ogr.spec"
+    downstream_specfile_path = "python-ogr.spec"
+
+    assert pc.get_specfile_sync_files_item() == SyncFilesItem(
+        src=[upstream_specfile_path], dest=downstream_specfile_path
+    )
+    assert pc.get_specfile_sync_files_item(from_downstream=True) == SyncFilesItem(
+        src=[downstream_specfile_path], dest=upstream_specfile_path
+    )
+
+
 @pytest.mark.parametrize(
     "raw",
     [


### PR DESCRIPTION
If the upstream spec file is located in a subdirectory (such as
packaging/fedora/pkg.spec), it should be synced to the root of
the downstream repository, since that's where rpmbuild will look
for it.

Fixes https://github.com/packit/packit/issues/1401

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>
