### PR TITLE
Change the trigger for PyPI publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,7 +5,7 @@ name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
   release:
-    types: [created]
+    types: [released]
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
Since we changed the workflow for creating releases and we now create draft releases first, with the created release action we don't trigger the workflow.
