### PR TITLE
fix(find srpm): if more lines after 'Wrote' line

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -820,7 +820,9 @@ class SRPMBuilder:
         """
         logger.debug(f"The `rpmbuild` command output: {output}")
         # not doing 'Wrote: (.+)' since people can have different locales; hi Franto!
-        reg = r": (\S+\.src\.rpm)$"
+        reg = r": (\S+\.src\.rpm)"
+        # also, we can't suffix this with '$' because rpmbuild can put additional content after
+        # e.g. warnings when parsing the spec file
         try:
             the_srpm = re.findall(reg, output)[0]
         except IndexError:

--- a/tests/unit/test_upstream.py
+++ b/tests/unit/test_upstream.py
@@ -340,6 +340,30 @@ def test_release_suffix(
 
 
 @pytest.mark.parametrize(
+    "rpmbuild_output",
+    (
+        pytest.param(
+            "setting SOURCE_DATE_EPOCH=1668038400"
+            "Wrote: ./koji-c-1.1.0-1.20221110110837054647.pr257.1.g8477d03.fc35.src.rpm"
+            "RPM build warnings:"
+            "    extra tokens at the end of %endif directive in line 66:  %endif # with_python3",
+            id="output_after",
+        ),
+        pytest.param(
+            "setting SOURCE_DATE_EPOCH=1668038400"
+            "Wrote: ./koji-c-1.1.0-1.20221110110837054647.pr257.1.g8477d03.fc35.src.rpm",
+            id="common_output",
+        ),
+    ),
+)
+def test_get_srpm_from_rpmbuild_output(upstream_mock, rpmbuild_output):
+    srpm = "./koji-c-1.1.0-1.20221110110837054647.pr257.1.g8477d03.fc35.src.rpm"
+    assert srpm == SRPMBuilder(upstream_mock)._get_srpm_from_rpmbuild_output(
+        rpmbuild_output
+    )
+
+
+@pytest.mark.parametrize(
     "bump_version,release_suffix,expected_release_suffix",
     (
         # current_git_tag_version="4.5"


### PR DESCRIPTION
rpmbuild can append more lines after the 'Wrote' line, so we cannot have
'$' in the regex, example:

    warning: extra tokens at the end of %endif directive in line 66:  %endif # with_python3
    setting SOURCE_DATE_EPOCH=1668038400
    Wrote: ./koji-containerbuild-1.1.0-1.20221110110837054647.pr257.1.g8477d03.fc35.src.rpm
    RPM build warnings:
        extra tokens at the end of %endif directive in line 66:  %endif # with_python3

The former regex would not find the SRPM in the output above. This commit fixes it.


TODO:

- [x] Write new tests or update the old ones to cover new functionality.

Fixes sentry issue: PCKT-002-PACKIT-SERVICE-4VP

RELEASE NOTES BEGIN

Packit now correctly finds SRPM when rpmbuild reports warnings when it parses the spec file.

RELEASE NOTES END