### PR TITLE
fix(copr): don't branch Fedora by default

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1549,6 +1549,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         release_suffix: Optional[str] = None,
         srpm_path: Optional[Path] = None,
         module_hotfixes: bool = False,
+        follow_fedora_branching: bool = False,
     ) -> Tuple[int, str]:
         """
         Submit a build to copr build system using an SRPM using the current checkout.
@@ -1577,6 +1578,8 @@ The first dist-git commit to be synced is '{short_hash}'.
                 to the implicit creation of the SRPM.
             module_hotfixes: Specifies whether copr should make packages from this
                 project available along with packages from the active module streams.
+            follow_fedora_branching: If newly branched chroots should be
+                automatically enabled and populated.
 
         Returns:
             ID of the created build and URL to the build web page.
@@ -1607,6 +1610,7 @@ The first dist-git commit to be synced is '{short_hash}'.
             additional_repos=additional_repos,
             request_admin_if_needed=request_admin_if_needed,
             module_hotfixes=module_hotfixes,
+            follow_fedora_branching=follow_fedora_branching,
         )
         logger.debug(
             f"Submitting a build to copr build system,"

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -182,6 +182,7 @@ class CommonPackageConfig:
         image_request: Optional[Dict] = None,
         image_customizations: Optional[Dict] = None,
         copr_chroot: Optional[str] = None,
+        follow_fedora_branching: bool = False,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -276,6 +277,8 @@ class CommonPackageConfig:
         self.image_request = image_request
         self.image_customizations = image_customizations
         self.copr_chroot = copr_chroot
+
+        self.follow_fedora_branching = follow_fedora_branching
 
     @property
     def targets_dict(self):

--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -147,6 +147,7 @@ class CoprHelper:
         request_admin_if_needed: bool = False,
         targets_dict: Optional[Dict] = None,  # chroot specific configuration
         module_hotfixes: bool = False,
+        follow_fedora_branching: bool = False,
     ) -> None:
         """
         Create a project in copr if it does not exists.
@@ -180,6 +181,7 @@ class CoprHelper:
                 additional_repos=additional_repos,
                 targets_dict=targets_dict,
                 module_hotfixes=module_hotfixes,
+                follow_fedora_branching=follow_fedora_branching,
             )
             return
         except CoprRequestException as ex:
@@ -339,6 +341,7 @@ class CoprHelper:
         additional_repos: Optional[List[str]] = None,
         targets_dict: Optional[Dict] = None,  # chroot specific configuration
         module_hotfixes: bool = False,
+        follow_fedora_branching: bool = False,
     ) -> None:
         try:
             self.copr_client.project_proxy.add(
@@ -362,6 +365,7 @@ class CoprHelper:
                 f"This copr project is created and handled by the packit project "
                 "(https://packit.dev/).",
                 module_hotfixes=module_hotfixes,
+                follow_fedora_branching=follow_fedora_branching,
             )
             # once created: update chroot-specific configuration if there is any
             self._update_chroot_specific_configuration(


### PR DESCRIPTION
When creating and submitting Copr builds, we use the defualts from Copr that result in enabling the Fedora branching on Copr' side. This can result in performance degradation on Copr' side, since they also branch PR builds that are not expected to be branched.

As of now, do not update existing Copr projects, but start submitting them with the branching feature disabled.

^^^ This could be changed, but the information about the branching is not yet returned from the Copr API (it only processes it during creation and editing of the Copr project).

Fixes packit/packit-service#1651

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`. (packit/packit.dev#657)
- [x] ~~Use the value provided by the Copr API to check whether we need to adjust the `follow_fedora_branching` or not **blocked by the Copr deployment on 5/25**~~ not relevant

<!-- notes for reviewers -->


RELEASE NOTES BEGIN

Copr projects created by Packit will not follow the Fedora branching from now. This decision has been made to lower the load on Copr from the temporary Copr projects created, mainly, for the PR builds. If you are releasing your packages to the Copr, please use the new setting `follow_fedora_branching`.

Already existing projects are not affected by this change and it is also not enforced with the custom Copr repositories.

RELEASE NOTES END
