### PR TITLE
Fix Dubious Ownership in requre

### DIFF
--- a/tests_recording/main.fmf
+++ b/tests_recording/main.fmf
@@ -28,3 +28,10 @@ adjust:
     because: "flexmock is not in EPEL 10: https://bugzilla.redhat.com/show_bug.cgi?id=2351835"
     require-:
       - python3-flexmock
+
+  - when: initiator == packit
+    because: "Fix Dubious Ownership, add a safe directory exception for CI"
+    prepare+:
+     - how: shell
+       name: fix-dubious-ownership-for-tmp
+       script: 'git config --global safe.directory /tmp/*'


### PR DESCRIPTION
reverse testing in requre is failing with the following indication:

E             stderr: 'fatal: detected dubious ownership in repository at '/tmp/tmpco60quxn'
E           To add an exception for this directory, call:
E
E           	git config --global --add safe.directory /tmp/tmpco60quxn'