### PR TITLE
Make packit init use the latest version of precommit hook

### DIFF
--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -13,12 +13,19 @@ from typing import Optional, Union
 import click
 from github import GithubException
 from ogr.parsing import parse_git_repo
+from ogr.services.github import GithubService
 
 from packit.api import PackitAPI
 from packit.config import Config, JobType, get_local_package_config
 from packit.config.common_package_config import MultiplePackages
 from packit.config.package_config import PackageConfig
-from packit.constants import CONFIG_FILE_NAMES, DISTRO_DIR, SRC_GIT_CONFIG
+from packit.constants import (
+    CONFIG_FILE_NAMES,
+    DISTRO_DIR,
+    PACKIT_NAMESPACE,
+    PRECOMMIT_HOOK_REPO,
+    SRC_GIT_CONFIG,
+)
 from packit.exceptions import PackitException, PackitNotAGitRepoException
 from packit.local_project import LocalProject
 
@@ -374,6 +381,14 @@ def get_existing_config(working_dir: Path) -> Optional[Path]:
 
 def get_precommit_config(working_dir: Path) -> Optional[Path]:
     return get_file(working_dir, ".pre-commit-config.yaml")
+
+
+def get_latest_precommit_hook_release() -> Optional[str]:
+    service = GithubService(token=None)
+    project = service.get_project(repo=PRECOMMIT_HOOK_REPO, namespace=PACKIT_NAMESPACE)
+
+    release = project.get_latest_release()
+    return release.tag_name if release else None
 
 
 def get_file(working_dir: Path, filename: str) -> Optional[Path]:

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -5,6 +5,10 @@ import itertools
 
 from packit.dist_git_instance import DistGitInstance
 
+PACKIT_NAMESPACE = "packit"
+
+PRECOMMIT_HOOK_REPO = "pre-commit-hooks"
+
 DG_PR_COMMENT_KEY_SG_PR = "Source-git pull request ID"
 DG_PR_COMMENT_KEY_SG_COMMIT = "Source-git commit"
 
@@ -89,10 +93,9 @@ upstream_package_name: {upstream_package_name}
 downstream_package_name: {downstream_package_name}
 """
 
-PRECOMMIT_CONFIG = {
+PRECOMMIT_CONFIG_TEMPLATE = {
     # check validity of Packit configuration
     "repo": "https://github.com/packit/pre-commit-hooks",
-    "rev": "v1.3.0",
     "hooks": [{"id": "validate-config"}],
 }
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -51,6 +51,14 @@ HELLO_RELEASE = "1.0.1"
 
 
 @pytest.fixture()
+def mock_precommit_release():
+    project = flexmock()
+    release = flexmock(tag_name="v1.1.1")
+    flexmock(GithubService).should_receive("get_project").and_return(project)
+    project.should_receive("get_latest_release").and_return(release)
+
+
+@pytest.fixture()
 def mock_remote_functionality_upstream(upstream_and_remote, distgit_and_remote):
     u, _ = upstream_and_remote
     d, _ = distgit_and_remote

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -3,14 +3,17 @@
 
 import copy
 
+import pytest
 import yaml
 
 from packit.utils.commands import cwd
 from tests.spellbook import call_packit
 
+pytestmark = pytest.mark.usefixtures("mock_precommit_release")
+
 PACKIT_PRECOMMIT_CONFIG = {
     "repo": "https://github.com/packit/pre-commit-hooks",
-    "rev": "v1.3.0",
+    "rev": "v1.1.1",
     "hooks": [{"id": "validate-config"}],
 }
 
@@ -50,7 +53,9 @@ def test_init_fail(cwd_upstream_or_distgit):
     assert result.exit_code == 2  # packit config already exists --force needed
 
 
-def test_init_force_precommit_flag(upstream_without_precommit_config_not_bare):
+def test_init_force_precommit_flag(
+    upstream_without_precommit_config_not_bare,
+):
     result = call_packit(
         parameters=["init", "--force-precommit"],
         working_dir=upstream_without_precommit_config_not_bare,
@@ -115,7 +120,9 @@ def test_init_missing_precommit_config(upstream_without_precommit_config_not_bar
     assert not (config_file).is_file()
 
 
-def test_init_empty_precommit_config(upstream_without_config_not_bare):
+def test_init_empty_precommit_config(
+    upstream_without_config_not_bare,
+):
     config_file = upstream_without_config_not_bare / ".pre-commit-config.yaml"
 
     result = call_packit(
@@ -132,7 +139,9 @@ def test_init_empty_precommit_config(upstream_without_config_not_bare):
     assert data == expected
 
 
-def test_init_random_precommit_config(upstream_without_config_not_bare):
+def test_init_random_precommit_config(
+    upstream_without_config_not_bare,
+):
     config_file = upstream_without_config_not_bare / ".pre-commit-config.yaml"
     random_data = "Random file content"
     with open(config_file, "w") as f:
@@ -151,7 +160,9 @@ def test_init_random_precommit_config(upstream_without_config_not_bare):
         assert random_data == data
 
 
-def test_init_invalid_syntax_precommit_config(upstream_without_config_not_bare):
+def test_init_invalid_syntax_precommit_config(
+    upstream_without_config_not_bare,
+):
     config_file = upstream_without_config_not_bare / ".pre-commit-config.yaml"
     data = copy.deepcopy(INVALID_PRECOMMIT_CONFIG)
 
@@ -171,7 +182,9 @@ def test_init_invalid_syntax_precommit_config(upstream_without_config_not_bare):
     assert data == INVALID_PRECOMMIT_CONFIG
 
 
-def test_init_valid_precommit_config(upstream_without_config_not_bare):
+def test_init_valid_precommit_config(
+    upstream_without_config_not_bare,
+):
     config_file = upstream_without_config_not_bare / ".pre-commit-config.yaml"
     data = copy.deepcopy(VALID_PRECOMMIT_CONFIG)
 
@@ -241,7 +254,9 @@ def test_init_preexisting_precommit_config_different_rev(
     assert data == expected
 
 
-def test_init_search_for_specfile_root(upstream_without_config_not_bare):
+def test_init_search_for_specfile_root(
+    upstream_without_config_not_bare,
+):
     with cwd(upstream_without_config_not_bare):
         (upstream_without_config_not_bare / "file.spec").touch()
         call_packit(parameters=["init"])
@@ -250,7 +265,9 @@ def test_init_search_for_specfile_root(upstream_without_config_not_bare):
             assert "\nspecfile_path: file.spec\n" in f.read()
 
 
-def test_init_search_for_specfile_recursive(upstream_without_config_not_bare):
+def test_init_search_for_specfile_recursive(
+    upstream_without_config_not_bare,
+):
     with cwd(upstream_without_config_not_bare):
         nested_path = upstream_without_config_not_bare / "awesome_directory" / "nested"
         nested_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
`packit init` now uses `ogr` to find the latest version of precommit hook added to the user's precommit configuration file. Tests have also been changed to reflect this. Tests, which would otherwise result in calling the Github API, now use flexmock to mock the GithubService class (using `mock_precommit_release`).

<!-- TODO list -->


<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes [#2648](https://github.com/packit/packit/issues/2648)

<!-- release notes footer -->

RELEASE NOTES BEGIN

`packit init` now automatically retrieves the latest version of the pre-commit hook to be added to the user's pre-commit configuration file. 

RELEASE NOTES END
