### PR TITLE
CLI: Add pull-from-upstream --dry-run option

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -923,6 +923,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         sync_acls: Optional[bool] = False,
         fast_forward_merge_branches: Optional[set[str]] = None,
         warn_about_koji_build_triggering_bug: bool = False,
+        dry_run: bool = False,
     ) -> tuple[PullRequest, dict[str, PullRequest]]:
         """Overload for type-checking; return PullRequest if create_pr=True."""
 
@@ -951,6 +952,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         sync_acls: Optional[bool] = False,
         fast_forward_merge_branches: Optional[set[str]] = None,
         warn_about_koji_build_triggering_bug: bool = False,
+        dry_run: bool = False,
     ) -> None:
         """Overload for type-checking; return None if create_pr=False."""
 
@@ -978,6 +980,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         sync_acls: Optional[bool] = False,
         fast_forward_merge_branches: Optional[set[str]] = None,
         warn_about_koji_build_triggering_bug: bool = False,
+        dry_run: bool = False,
     ) -> Optional[tuple[PullRequest, dict[str, PullRequest]]]:
         """
         Update given package in dist-git
@@ -1014,6 +1017,8 @@ The first dist-git commit to be synced is '{short_hash}'.
                 fork when creating a PR from fork.
             fast_forward_merge_branches: Set of branches `dist_git_branch` should be
                 fast-forward-merged into.
+            dry_run: If True, skip all remote operations (no upload to lookaside cache,
+                no push to remote, no PR creation). Only update local dist-git files.
 
         Returns:
             Tuple of the created (or existing if one already exists) PullRequest and
@@ -1298,7 +1303,12 @@ The first dist-git commit to be synced is '{short_hash}'.
                 if warn_about_koji_build_triggering_bug:
                     self._warn_about_koji_build_triggering_bug_if_needed(pr)
             else:
-                self.dg.push(refspec=f"HEAD:{dist_git_branch}")
+                if not dry_run:
+                    self.dg.push(refspec=f"HEAD:{dist_git_branch}")
+                else:
+                    logger.info(
+                        f"Dry-run mode: skipping push to remote 'origin' on branch '{dist_git_branch}'.",
+                    )
         finally:
             # version should hold the plain version string
             if version.startswith("v"):

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -56,6 +56,7 @@ def sync_release(
     dist_git_path,
     dist_git_branch,
     force_new_sources,
+    dry_run,
     pr,
     local_content,
     path_or_url,
@@ -75,7 +76,12 @@ def sync_release(
         local_project=path_or_url,
         check_for_non_git_upstream=check_for_non_git_upstream,
     )
-    if pr is None:
+
+    # In dry-run mode, override settings to prevent remote operations
+    if dry_run:
+        click.echo("Running in dry-run mode: no remote operations will be performed.")
+        pr = False
+    elif pr is None:
         pr = api.package_config.create_pr
 
     branches_to_update = get_dg_branches(
@@ -102,6 +108,7 @@ def sync_release(
             dist_git_branch=branch,
             use_local_content=local_content,
             versions=[version] if version else [],
+            add_new_sources=not dry_run,
             force_new_sources=force_new_sources,
             upstream_ref=upstream_ref,
             create_pr=pr,
@@ -109,6 +116,7 @@ def sync_release(
             use_downstream_specfile=use_downstream_specfile,
             resolved_bugs=resolve_bug,
             sync_acls=sync_acls,
+            dry_run=dry_run,
             fast_forward_merge_branches=get_fast_forward_merge_branches_for(
                 dist_git_branches=dist_git_branches,
                 source_branch=branch,
@@ -133,6 +141,13 @@ def sync_release_common_options(func):
         is_flag=True,
         default=False,
         help="Upload the new sources also when the archive is already in the lookaside cache.",
+    )
+    @click.option(
+        "--dry-run",
+        is_flag=True,
+        default=False,
+        help="Do not perform any remote operations (no upload, no push, no PR). "
+        "Only update local dist-git files for inspection.",
     )
     @click.option(
         "--pr/--no-pr",
@@ -206,6 +221,7 @@ def propose_downstream(
     dist_git_path,
     dist_git_branch,
     force_new_sources,
+    dry_run,
     pr,
     path_or_url,
     version,
@@ -230,6 +246,7 @@ def propose_downstream(
         dist_git_path=dist_git_path,
         dist_git_branch=dist_git_branch,
         force_new_sources=force_new_sources,
+        dry_run=dry_run,
         pr=pr,
         path_or_url=path_or_url,
         version=version,
@@ -253,6 +270,7 @@ def pull_from_upstream(
     dist_git_path,
     dist_git_branch,
     force_new_sources,
+    dry_run,
     pr,
     path_or_url,
     version,
@@ -275,6 +293,7 @@ def pull_from_upstream(
         dist_git_path=dist_git_path,
         dist_git_branch=dist_git_branch,
         force_new_sources=force_new_sources,
+        dry_run=dry_run,
         pr=pr,
         path_or_url=path_or_url,
         version=version,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -115,5 +115,7 @@ def test_pull_from_upstream_with_dry_run():
         resolve_bug=None,
         sync_acls=False,
     ).and_return()
-    result = call_packit(packit_base, parameters=["pull-from-upstream", ".", "--dry-run"])
+    result = call_packit(
+        packit_base, parameters=["pull-from-upstream", ".", "--dry-run"],
+    )
     assert result.exit_code == 0

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -52,6 +52,7 @@ def test_propose_downstream_command():
         dist_git_path=None,
         dist_git_branch=None,
         force_new_sources=False,
+        dry_run=False,
         pr=None,
         path_or_url=LocalProject,
         version=None,
@@ -76,6 +77,7 @@ def test_pull_from_upstream_command():
         dist_git_path=None,
         dist_git_branch=None,
         force_new_sources=False,
+        dry_run=False,
         pr=None,
         path_or_url=LocalProject,
         version=None,
@@ -88,4 +90,30 @@ def test_pull_from_upstream_command():
         sync_acls=False,
     ).and_return()
     result = call_packit(packit_base, parameters=["pull-from-upstream", "."])
+    assert result.exit_code == 0
+
+
+def test_pull_from_upstream_with_dry_run():
+    """Test that --dry-run flag is properly passed to sync_release"""
+    flexmock(utils).should_receive("get_local_package_config").and_return(
+        flexmock().should_receive("get_package_config_views").and_return({}).mock(),
+    )
+    flexmock(propose_downstream_module).should_receive("sync_release").with_args(
+        config=Config,
+        dist_git_path=None,
+        dist_git_branch=None,
+        force_new_sources=False,
+        dry_run=True,
+        pr=None,
+        path_or_url=LocalProject,
+        version=None,
+        force=False,
+        local_content=False,
+        upstream_ref=None,
+        use_downstream_specfile=True,
+        package_config=PackageConfig,
+        resolve_bug=None,
+        sync_acls=False,
+    ).and_return()
+    result = call_packit(packit_base, parameters=["pull-from-upstream", ".", "--dry-run"])
     assert result.exit_code == 0


### PR DESCRIPTION
This is useful to see what `pull-from-upstream` would do without actually uploading/pushing anything.

RELEASE NOTES BEGIN
The `propose-downstream` and `pull-from-upstream` commands now have a `--dry-run` option which skips all uploads of new source tarballs, PR creation, and branch pushing. It only operates on the local checkout.
RELEASE NOTES END

---

I want to add packit configs to a bunch of Fedora packages that our team cares about. I don't want to actually send anything, just test my packit.yaml file. I couldn't find an existing way to do that, with e.g. `pull-from-upstream --pr` it fails very early on

> 2025-10-31 15:01:30.942 distgit.py        INFO   Downloading archives: ['nginx-1.29.3.tar.gz', 'nginx-1.29.3.tar.gz.asc', 'maxim.key', 'arut.key', 'pluknet.key', 'sb.key', 'thresh.key']
> 2025-10-31 15:01:33.573 distgit.py        INFO   About to upload to lookaside cache.
> 2025-10-31 15:01:34.007 logging.py        INFO   Uploading: /var/home/martin/tmp/nginx/nginx-1.29.3.tar.gz to https://src.fedoraproject.org/repo/pkgs/upload.cgi
> 2025-10-31 15:01:34.359 logging.py        INFO   Could not execute new_sources: Dist-git request is unauthorized.

before it actually does any change to dist-git.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`. (will have a look after initial review)