### PR TITLE
Fix inconsistent CLI command names

### DIFF
--- a/packit/cli/init.py
+++ b/packit/cli/init.py
@@ -42,13 +42,13 @@ logger = logging.getLogger(__name__)
     help="Reset config to default if already exists.",
 )
 @click.option(
-    "--without_precommit",
+    "--without-precommit",
     default=False,
     is_flag=True,
     help="Skip adding packit-specific pre-commit configuration hook.",
 )
 @click.option(
-    "--force_precommit",
+    "--force-precommit",
     default=False,
     is_flag=True,
     help="Create pre-commit configuration file if missing.",
@@ -68,7 +68,7 @@ def init(config, path_or_url, force, without_precommit, force_precommit):
 
     if without_precommit and force_precommit:
         raise PackitException(
-            "--without_precommit and --force_precommit are"
+            "--without-precommit and --force-precommit are"
             " mutually exclusive flags.",
         )
 
@@ -160,7 +160,7 @@ def init_precommit(
             " Initialize current repository as a git repo first in order"
             " to set up Packit config validation upon pre-commit."
             " If you want do not want to use pre-commit for this purpose,"
-            " re-run `packit init` using `--without_precommit` flag.",
+            " re-run `packit init` using `--without-precommit` flag.",
         )
 
     generate_precommit_config(precommit_config_path)

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -52,7 +52,7 @@ def test_init_fail(cwd_upstream_or_distgit):
 
 def test_init_force_precommit_flag(upstream_without_precommit_config_not_bare):
     result = call_packit(
-        parameters=["init", "--force_precommit"],
+        parameters=["init", "--force-precommit"],
         working_dir=upstream_without_precommit_config_not_bare,
     )
 
@@ -76,7 +76,7 @@ def test_init_without_precommit_flag(upstream_without_config_not_bare):
         yaml.dump(user_data, f, default_flow_style=False)
 
     result = call_packit(
-        parameters=["init", "--without_precommit"],
+        parameters=["init", "--without-precommit"],
         working_dir=upstream_without_config_not_bare,
     )
 
@@ -93,7 +93,7 @@ def test_init_without_precommit_flag(upstream_without_config_not_bare):
 
 def test_init_exclusive_flags(upstream_without_precommit_config_not_bare):
     result = call_packit(
-        parameters=["init", "--without_precommit", "--force_precommit"],
+        parameters=["init", "--without-precommit", "--force-precommit"],
         working_dir=upstream_without_precommit_config_not_bare,
     )
 


### PR DESCRIPTION
The two commands `--without_precommit` and `--force_precommit` have been renamed to `--without-precommit` and `--force-precommit` in order to maintain consistency across CLI commands when it comes to naming conventions.

<!-- TODO list -->

TODO:

- [x] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

Note: Documentation already refers to these two commands as  `--without-precommit` and `--force-precommit`. No changes are needed there.

Fixes [#2660](https://github.com/packit/packit/issues/2660)

Related to [#1064](https://github.com/packit/packit.dev/pull/1064/files)
