### PR TITLE
Implement method for cancelling Koji tasks

### DIFF
--- a/packit/utils/koji_helper.py
+++ b/packit/utils/koji_helper.py
@@ -398,6 +398,24 @@ class KojiHelper:
         except Exception as e:
             logger.debug(f"Failed to untag {nvr} from {tag} in Koji: {e}")
 
+    def cancel_task(self, task_id: int) -> bool:
+        """
+        Cancels a task and its children recursively.
+
+        Args:
+            task_id: Koji task ID.
+
+        Returns:
+            Whether the cancellation was successful.
+        """
+        logger.info(f"Cancelling Koji task with ID {task_id}")
+        try:
+            self.session.cancelTask(task_id, recurse=True)
+            return True
+        except Exception as e:
+            logger.debug(f"Failed to cancel Koji task {task_id}: {e}")
+            return False
+
     def get_build_target(self, dist_git_branch: str) -> Optional[dict]:
         """
         Gets a build target from a dist-git branch name.

--- a/tests/unit/utils/test_koji_helper.py
+++ b/tests/unit/utils/test_koji_helper.py
@@ -302,6 +302,28 @@ def test_untag_build(logged_in):
 
 
 @pytest.mark.parametrize(
+    "logged_in, error",
+    [(True, False), (False, False), (True, True)],
+)
+def test_cancel_task(logged_in, error):
+    @koji_session_virtual_method(requires_authentication=not logged_in)
+    def cancelTask(*_, **__):
+        if error:
+            raise Exception
+
+    session = flexmock(cancelTask=cancelTask)
+    session.should_receive("gssapi_login").times(
+        0 if logged_in else 1,
+    )
+    flexmock(ClientSession).new_instances(session)
+    result = KojiHelper().cancel_task(12345)
+    if error:
+        assert result is False
+    else:
+        assert result is True
+
+
+@pytest.mark.parametrize(
     "error",
     [False, True],
 )


### PR DESCRIPTION
Koji API provides several methods for canceling builds/tasks:

- cancelBuild(buildID, strict=False) - cancel particular build and its associated task.
- cancelTask(task_id, recurse=True) - cancel a task and its child tasks.
- cancelTaskChildren(task_id) - cancel only children but not the task itself.
- cancelTaskFull(task_id, strict=True) - cancel task and all tasks in its group, but require admin permission.

Since packit-service doesn't have admin permission and doesn't store the IDs of particular builds, this patch implements support only for the `cancelTask()` method. This is sufficient for cancelling both scratch and production builds - packit-service stores task ID for both variants in KojiBuildTargetModel.task_id.

<!-- TODO list -->

TODO:

- [x] https://github.com/packit/packit-service/issues/2989

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes https://github.com/packit/packit/issues/2535