### PR TITLE
Reset the `working_dir` property after clean-up

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -450,6 +450,11 @@ class NonGitUpstream(Upstream):
         logger.debug(f"Cleaning: {self.working_dir}")
         shutil.rmtree(self.working_dir, ignore_errors=True)
 
+        # invalidate cached properties depending on working dir
+        self._working_dir = None
+        self._command_handler = None
+        self._actions_handler = None
+
 
 class GitUpstream(PackitRepositoryBase, Upstream):
     """Interact with git upstream project"""


### PR DESCRIPTION
In service, the `NonGitUpstream` instance is being reused for all branches, but at the end of every run a clean-up is performed that removes the working directory but doesn't reset the `working_dir` property so the next run doesn't create the working directory again and fails during file syncing. Fix that.