### PR TITLE
Fix variable hash in .git_archival.txt and exclude it from sdist (#2692)

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,4 +1,3 @@
 node: $Format:%H$
 node-date: $Format:%cI$
 describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
-ref-names: $Format:%D$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,11 @@ raw-options.version_scheme = "no-guess-dev"
 [tool.hatch.build.targets.wheel]
 packages = ["packit"]
 
+[tool.hatch.build.targets.sdist]
+exclude = [
+  ".git_archival.txt",
+]
+
 [tool.pytest.ini_options]
 filterwarnings = "ignore::DeprecationWarning"
 addopts = '-m "not slow"'


### PR DESCRIPTION
Remove the ref-names field from .git_archival.txt which was causing different file hashes depending on whether the commit is HEAD or not. This ensures reproducible builds and stable package hashes.

The ref-names field is not required by hatch-vcs for version detection; the node, node-date, and describe-name fields are sufficient.

Also exclude .git_archival.txt from source distributions as it's only needed when building from git archives, not from published sdists.

Should fix #2692