### PR TITLE
Remove extra line before Resolve bugs

### DIFF
--- a/packit/utils/changelog_helper.py
+++ b/packit/utils/changelog_helper.py
@@ -149,12 +149,12 @@ class ChangelogHelper:
                 name=full_version,
             ).body
             if release_description:
-                comment = release_description
+                # remove extra newlines at the end
+                comment = release_description.rstrip()
 
         if not action_output and resolved_bugs:
-            comment += "\n"
-            for bug in resolved_bugs:
-                comment += f"- Resolves: {bug}\n"
+            bug_lines = "\n".join(f"- Resolves: {bug}" for bug in resolved_bugs)
+            comment += f"\n{bug_lines}"
 
         return self.sanitize_entry(comment)
 

--- a/packit/utils/changelog_helper.py
+++ b/packit/utils/changelog_helper.py
@@ -137,7 +137,8 @@ class ChangelogHelper:
             previous_version=previous_specfile_version,
         )
 
-        comment = action_output or default_changelog_entry
+        # Remove extra newlines at the end for consistency
+        comment = (action_output or default_changelog_entry).rstrip()
         if (
             self.package_config.copy_upstream_release_description
             # in pull_from_upstream workflow, upstream git_project can be None
@@ -149,7 +150,6 @@ class ChangelogHelper:
                 name=full_version,
             ).body
             if release_description:
-                # remove extra newlines at the end
                 comment = release_description.rstrip()
 
         if not action_output and resolved_bugs:

--- a/tests/integration/test_changelog_helper.py
+++ b/tests/integration/test_changelog_helper.py
@@ -172,6 +172,30 @@ def test_update_distgit_multiple_resolved_bugs(
         assert expected in changelog_str
 
 
+def test_update_distgit_action_output_trailing_newlines(
+    upstream,
+    distgit_instance,
+):
+    """Test that trailing newlines in changelog action output are removed."""
+    _, downstream = distgit_instance
+    package_config = upstream.package_config
+    # Echo command produces trailing newline, printf adds extra newlines
+    package_config.actions = {
+        ActionName.changelog_entry: "printf '- Custom entry from action\\n\\n'",
+    }
+
+    ChangelogHelper(upstream, downstream, package_config).update_dist_git(
+        upstream_tag="0.1.0",
+        full_version="0.1.0",
+    )
+
+    with downstream._specfile.sections() as sections:
+        changelog_str = str(sections.changelog)
+        # Verify action output with trailing newlines stripped (one blank line before next entry)
+        expected = "- Custom entry from action\n\n* Sun Feb 24 2019"
+        assert expected in changelog_str
+
+
 @pytest.mark.skipif(
     rpm.__version__ < "4.16",
     reason="%autochangelog requires rpm 4.16 or higher",

--- a/tests/integration/test_changelog_helper.py
+++ b/tests/integration/test_changelog_helper.py
@@ -115,6 +115,63 @@ def test_update_distgit_when_copy_upstream_release_description(
         assert "- Resolves: rhbz#123" in sections.changelog
 
 
+def test_update_distgit_release_description_with_trailing_newlines(
+    upstream,
+    distgit_instance,
+):
+    """Test that trailing newlines in release description are removed."""
+    _, downstream = distgit_instance
+    package_config = upstream.package_config
+    package_config.copy_upstream_release_description = True
+    upstream.local_project.git_project = (
+        flexmock()
+        .should_receive("get_release")
+        .with_args(tag_name="0.1.0", name="0.1.0")
+        .and_return(flexmock(body="Some release 0.1.0\n\n"))
+        .mock()
+    )
+
+    ChangelogHelper(upstream, downstream, package_config).update_dist_git(
+        upstream_tag="0.1.0",
+        full_version="0.1.0",
+        resolved_bugs=["rhbz#123"],
+    )
+
+    with downstream._specfile.sections() as sections:
+        changelog_str = str(sections.changelog)
+        # Verify the description and bug line are consecutive (no blank line between)
+        assert "Some release 0.1.0\n- Resolves: rhbz#123" in changelog_str
+
+
+def test_update_distgit_multiple_resolved_bugs(
+    upstream,
+    distgit_instance,
+):
+    """Test that multiple resolved bugs are formatted on separate lines."""
+    _, downstream = distgit_instance
+    package_config = upstream.package_config
+    package_config.copy_upstream_release_description = True
+    upstream.local_project.git_project = (
+        flexmock()
+        .should_receive("get_release")
+        .with_args(tag_name="0.1.0", name="0.1.0")
+        .and_return(flexmock(body="Some release"))
+        .mock()
+    )
+
+    ChangelogHelper(upstream, downstream, package_config).update_dist_git(
+        upstream_tag="0.1.0",
+        full_version="0.1.0",
+        resolved_bugs=["rhbz#123", "rhbz#456", "rhbz#789"],
+    )
+
+    with downstream._specfile.sections() as sections:
+        changelog_str = str(sections.changelog)
+        # Verify release description followed by bugs with only single newlines
+        expected = "Some release\n- Resolves: rhbz#123\n- Resolves: rhbz#456\n- Resolves: rhbz#789"
+        assert expected in changelog_str
+
+
 @pytest.mark.skipif(
     rpm.__version__ < "4.16",
     reason="%autochangelog requires rpm 4.16 or higher",


### PR DESCRIPTION
RELEASE NOTES BEGIN

We've fixed the formatting of the strings Packit appends to the changelog. Now there will be at most one blank line before or after the Packit comment.

RELEASE NOTES END