### PR TITLE
Revert "Check for configured `koji_build` job on service side"

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -35,7 +35,6 @@ from ogr.abstract import PullRequest
 from ogr.exceptions import PagureAPIException
 from ogr.services.gitlab.project import GitlabProject
 from ogr.services.pagure.project import PagureProject
-from ogr.services.pagure.pull_request import PagurePullRequest
 from tabulate import tabulate
 
 from packit.actions import ActionName
@@ -923,7 +922,6 @@ The first dist-git commit to be synced is '{short_hash}'.
         pr_description_footer: Optional[str] = None,
         sync_acls: Optional[bool] = False,
         fast_forward_merge_branches: Optional[set[str]] = None,
-        warn_about_koji_build_triggering_bug: bool = False,
     ) -> tuple[PullRequest, dict[str, PullRequest]]:
         """Overload for type-checking; return PullRequest if create_pr=True."""
 
@@ -951,7 +949,6 @@ The first dist-git commit to be synced is '{short_hash}'.
         pr_description_footer: Optional[str] = None,
         sync_acls: Optional[bool] = False,
         fast_forward_merge_branches: Optional[set[str]] = None,
-        warn_about_koji_build_triggering_bug: bool = False,
     ) -> None:
         """Overload for type-checking; return None if create_pr=False."""
 
@@ -978,7 +975,6 @@ The first dist-git commit to be synced is '{short_hash}'.
         pr_description_footer: Optional[str] = None,
         sync_acls: Optional[bool] = False,
         fast_forward_merge_branches: Optional[set[str]] = None,
-        warn_about_koji_build_triggering_bug: bool = False,
     ) -> Optional[tuple[PullRequest, dict[str, PullRequest]]]:
         """
         Update given package in dist-git
@@ -1284,20 +1280,12 @@ The first dist-git commit to be synced is '{short_hash}'.
                         pr_title = (
                             title or f"Update {ff_branch} to upstream release {version}"
                         )
-                        ff_branch_pr = self.create_or_update_pr(
+                        ff_prs[ff_branch] = self.create_or_update_pr(
                             pr_title=pr_title,
                             pr_description=f"{pr_description}{pr_instructions}{footer}",
                             target_branch=ff_branch,
                             repo=self.dg,
                         )
-                        ff_prs[ff_branch] = ff_branch_pr
-                        if warn_about_koji_build_triggering_bug:
-                            self._warn_about_koji_build_triggering_bug_if_needed(
-                                ff_branch_pr,
-                            )
-
-                if warn_about_koji_build_triggering_bug:
-                    self._warn_about_koji_build_triggering_bug_if_needed(pr)
             else:
                 self.dg.push(refspec=f"HEAD:{dist_git_branch}")
         finally:
@@ -1701,34 +1689,6 @@ The first dist-git commit to be synced is '{short_hash}'.
                 logger.error(f"Update of existing PR {pr.url} failed: {exc}")
                 raise PackitException(f"Update of existing PR {pr.url} failed") from exc
         return pr
-
-    def _warn_about_koji_build_triggering_bug_if_needed(self, pr: PullRequest) -> None:
-        """
-        Adds a warning comment to a Pagure PR that is susceptible to a bug that breaks
-        Koji build triggering.
-
-        This method can be removed after https://github.com/packit/packit-service/issues/2537
-        is resolved.
-
-        Args:
-            pr: Newly created or updated pull request object.
-        """
-        if not isinstance(pr, PagurePullRequest):
-            logger.debug("Not a Pagure PR, skipping the warning comment.")
-            return
-
-        if pr._raw_pr["commit_start"] == pr._raw_pr["commit_stop"]:
-            # PR contains single commit
-            return
-
-        pr.comment(
-            "**Warning**\n"
-            "As this pull request contains more than one commit, you may be affected "
-            "by a [bug](https://github.com/packit/packit-service/issues/2537) "
-            "that will prevent the configured `koji_build` job(s) from being triggered "
-            "after this pull request is merged. If that happens, please [trigger the job manually]"
-            "(https://packit.dev/docs/fedora-releases-guide/dist-git-onboarding#retriggering).",
-        )
 
     def push_and_create_pr(
         self,

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -10,7 +10,6 @@ from flexmock import flexmock
 from munch import Munch
 from ogr.services.gitlab.project import GitlabProject
 from ogr.services.pagure.project import PagureProject
-from ogr.services.pagure.pull_request import PagurePullRequest
 
 from packit import api
 from packit import api as packit_api
@@ -215,33 +214,6 @@ def test_sync_release_create_sync_note(api_mock):
     )
     api_mock.should_receive("push_and_create_pr").and_return(flexmock())
     api_mock.sync_release(versions=["1.1"], dist_git_branch="_")
-
-
-def test_sync_release_warn_about_koji_build_triggering_bug(api_mock):
-    flexmock(PatchGenerator).should_receive("undo_identical")
-    flexmock(pathlib.Path).should_receive("write_text").once()
-    api_mock.up.should_receive("get_specfile_version").and_return("0")
-    api_mock.up.should_receive("specfile").and_return(
-        flexmock().should_receive("reload").mock(),
-    )
-    api_mock.up.package_config.should_receive("get_base_env").and_return({})
-    api_mock.dg.should_receive("push_to_fork").and_return()
-    api_mock.dg.should_receive("get_specfile_version").and_return("0")
-    api_mock.dg.should_receive("specfile").and_return(
-        flexmock().should_receive("reload").mock(),
-    )
-    pr = PagurePullRequest(
-        raw_pr={"commit_start": "1234abc", "commit_stop": "5678def", "branch": "_"},
-        project=flexmock(),
-    )
-    api_mock.dg.should_receive("create_pull").and_return(pr)
-    flexmock(api).should_receive("get_branches").and_return({"_", "__"})
-    flexmock(pr).should_receive("comment").once()
-    api_mock.sync_release(
-        versions=["1.1"],
-        dist_git_branch="_",
-        warn_about_koji_build_triggering_bug=True,
-    )
 
 
 def test_common_env(api_mock):


### PR DESCRIPTION
This reverts commit 0c69586e71db1a28eace839608e5635bd9ee1d4a.

Related to https://github.com/packit/packit-service/issues/2537.