### PR TITLE
Implement `version_update_specifiers` config option

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -35,6 +35,9 @@ from ogr.abstract import PullRequest
 from ogr.exceptions import PagureAPIException
 from ogr.services.gitlab.project import GitlabProject
 from ogr.services.pagure.project import PagureProject
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion
+from packaging.version import Version as PkgVersion
 from tabulate import tabulate
 
 from packit.actions import ActionName
@@ -852,6 +855,44 @@ The first dist-git commit to be synced is '{short_hash}'.
                 return False
         return True
 
+    def check_accepted_version(self, proposed: str) -> bool:
+        """
+        Check the proposed version against the configured PEP 440 version specifier set.
+
+        Args:
+            proposed: Version proposed to be synced.
+
+        Returns:
+            True if the proposed version satisfies the configured specifier set
+            or if the relevant configuration option is missing. False otherwise.
+        """
+        if not self.package_config.version_update_specifiers:
+            return True
+        try:
+            specifier_set = SpecifierSet(
+                self.package_config.version_update_specifiers,
+            )
+        except InvalidSpecifier:
+            logger.error(
+                f"Invalid version specifier set: "
+                f"{self.package_config.version_update_specifiers!r}",
+            )
+            return False
+        try:
+            proposed_version = PkgVersion(proposed)
+        except InvalidVersion:
+            logger.error(
+                f"Cannot parse proposed version {proposed!r} as PEP 440 version.",
+            )
+            return False
+        if proposed_version not in specifier_set:
+            logger.debug(
+                f"Proposed version {proposed} does not satisfy "
+                f"specifier set {self.package_config.version_update_specifiers!r}.",
+            )
+            return False
+        return True
+
     @staticmethod
     def get_upstream_release_monitoring_bug(
         package_name: str,
@@ -1148,6 +1189,14 @@ The first dist-git commit to be synced is '{short_hash}'.
                     "to skip this check.",
                 )
 
+            if not self.check_accepted_version(version):
+                raise ReleaseSkippedPackitException(
+                    f"The upstream released version {version} does not satisfy "
+                    f"the version_update_specifiers "
+                    f'"{self.package_config.version_update_specifiers}".'
+                    "\nYou can remove version_update_specifiers to skip this check.",
+                )
+
             self.dg.check_last_commit()
 
             self.up.actions_handler.run_action(
@@ -1274,6 +1323,15 @@ The first dist-git commit to be synced is '{short_hash}'.
                                 f'"{self.package_config.version_update_mask}".'
                                 "\nYou can change the version_update_mask with an empty string "
                                 "to skip this check.",
+                            )
+                            continue
+
+                        if not self.check_accepted_version(version):
+                            logger.info(
+                                f"The upstream released version {version} does not satisfy "
+                                f"the version_update_specifiers "
+                                f'"{self.package_config.version_update_specifiers}".'
+                                "\nYou can remove version_update_specifiers to skip this check.",
                             )
                             continue
 

--- a/packit/cli/dist_git_init.py
+++ b/packit/cli/dist_git_init.py
@@ -66,6 +66,11 @@ For more details, see https://packit.dev/docs/configuration/ or contact
     help="Python regex used for comparison of the old and the new version. ",
 )
 @click.option(
+    "--version-update-specifiers",
+    help="PEP 440 version specifier set (e.g. '>=1.0, <2.0') "
+    "used to filter the proposed version. ",
+)
+@click.option(
     "--issue-repository",
     help="URL of a git repository that can be used for reporting errors in form of issues. ",
 )
@@ -162,6 +167,7 @@ def init(
     upstream_tag_include,
     upstream_tag_exclude,
     version_update_mask,
+    version_update_specifiers,
     issue_repository,
     no_pull,
     no_koji_build,
@@ -277,6 +283,7 @@ def init(
         upstream_tag_include=upstream_tag_include,
         upstream_tag_exclude=upstream_tag_exclude,
         version_update_mask=version_update_mask,
+        version_update_specifiers=version_update_specifiers,
         issue_repository=issue_repository,
         no_pull=no_pull,
         no_koji_build=no_koji_build,
@@ -318,6 +325,7 @@ class DistGitInitializer:
         upstream_tag_include: Optional[str] = None,
         upstream_tag_exclude: Optional[str] = None,
         version_update_mask: Optional[str] = None,
+        version_update_specifiers: Optional[str] = None,
         issue_repository: Optional[str] = None,
         no_pull: bool = False,
         no_koji_build: bool = False,
@@ -339,6 +347,7 @@ class DistGitInitializer:
         self.upstream_tag_include = upstream_tag_include
         self.upstream_tag_exclude = upstream_tag_exclude
         self.version_update_mask = version_update_mask
+        self.version_update_specifiers = version_update_specifiers
         self.issue_repository = issue_repository
         self.no_pull = no_pull
         self.no_koji_build = no_koji_build
@@ -452,6 +461,7 @@ class DistGitInitializer:
             "upstream_tag_include",
             "upstream_tag_exclude",
             "version_update_mask",
+            "version_update_specifiers",
             "issue_repository",
             "allowed_committers",
             "allowed_pr_authors",

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -196,6 +196,9 @@ class CommonPackageConfig:
         version_update_mask: String containing a reg exp. The old version contained in the
             specfile and the newly released version have both to match this reg exp
             otherwise Packit shall not sync the release downstream.
+        version_update_specifiers: String containing a PEP 440 version specifier set
+            (comma-delimited, e.g. ">=1.0, <2.0"). The proposed version must satisfy
+            the specifier set, otherwise Packit shall not sync the release downstream.
         parse_time_macros: Dict with macros to (un)define before parsing specfile.
             Keys are macro names and values are macro values. A value of None will undefine
             the corresponding macro.
@@ -289,6 +292,7 @@ class CommonPackageConfig:
         upload_sources: bool = True,
         pkg_tool: Optional[str] = None,
         version_update_mask: Optional[str] = None,
+        version_update_specifiers: Optional[str] = None,
         test_command: Optional[TestCommandConfig] = None,
         parse_time_macros: Optional[dict[str, str]] = None,
         require: Optional[RequirementsConfig] = None,
@@ -357,6 +361,7 @@ class CommonPackageConfig:
         self.upstream_tag_include = upstream_tag_include
         self.upstream_tag_exclude = upstream_tag_exclude
         self.version_update_mask = version_update_mask
+        self.version_update_specifiers = version_update_specifiers
         self.prerelease_suffix_pattern = prerelease_suffix_pattern
         self.prerelease_suffix_macro = prerelease_suffix_macro
         self.test_command = test_command or TestCommandConfig()

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -16,6 +16,7 @@ from marshmallow import (
     pre_load,
     validates_schema,
 )
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
 
 from packit.actions import ActionName
 from packit.config import (
@@ -401,6 +402,17 @@ class JobMetadataSchema(Schema):
         return data
 
 
+def validate_version_specifiers(value):
+    """
+    marshmallow validation for a PEP 440 version specifier set.
+    """
+    try:
+        SpecifierSet(value)
+    except InvalidSpecifier as e:
+        raise ValidationError(f"Invalid version specifier set: {e}") from e
+    return True
+
+
 def validate_repo_name(value):
     """
     marshmallow validation for a repository name. Any
@@ -531,6 +543,10 @@ class CommonConfigSchema(Schema):
     pkg_tool = fields.String(load_default=None)
     sig = fields.String(load_default=None)
     version_update_mask = fields.String(load_default=None)
+    version_update_specifiers = fields.String(
+        load_default=None,
+        validate=validate_version_specifiers,
+    )
 
     parse_time_macros = fields.Dict(load_default=None)
     osh_diff_scan_after_copr_build = fields.Boolean(load_default=True)

--- a/tests/integration/test_validate_config.py
+++ b/tests/integration/test_validate_config.py
@@ -277,6 +277,36 @@ from packit.utils.commands import cwd
             False,
             " Repository name must be a valid filename.",
         ),
+        (
+            dedent(
+                """\
+                dist_git_base_url: https://packit.dev/
+                downstream_package_name: packit
+                upstream_ref: last_commit
+                upstream_package_name: packit_upstream
+                allowed_gpg_keys: [gpg]
+                dist_git_namespace: awesome
+                version_update_specifiers: ">=1.0, <2.0"
+            """,
+            ),
+            True,
+            "packit.yaml is valid and ready to be used",
+        ),
+        (
+            dedent(
+                """\
+                dist_git_base_url: https://packit.dev/
+                downstream_package_name: packit
+                upstream_ref: last_commit
+                upstream_package_name: packit_upstream
+                allowed_gpg_keys: [gpg]
+                dist_git_namespace: awesome
+                version_update_specifiers: "not a valid specifier"
+            """,
+            ),
+            False,
+            "version_update_specifiers: Invalid version specifier set:",
+        ),
     ],
     ids=[
         "valid_1",
@@ -295,6 +325,8 @@ from packit.utils.commands import cwd
         "wrong_fast_forward_merge_into_key",
         "allowed_gpg",
         "slash_in_package_name",
+        "valid_version_update_specifiers",
+        "invalid_version_update_specifiers",
     ],
 )
 def test_schema_validation(tmpdir, raw_package_config, valid, expected_output):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -92,6 +92,7 @@ def package_config_mock():
         is_sub_package=False,
         pkg_tool=None,
         version_update_mask="",
+        version_update_specifiers="",
         parse_time_macros={},
         version_suffix=None,
         release_suffix=None,

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -612,6 +612,83 @@ def test_check_version_distance(
 
 
 @pytest.mark.parametrize(
+    "proposed_version, version_update_specifiers, exp",
+    (
+        pytest.param(
+            "4.0.0",
+            None,
+            True,
+            id="no specifiers configured",
+        ),
+        pytest.param(
+            "4.0.0",
+            ">=3.0, <4.0",
+            False,
+            id="proposed version does not satisfy specifiers",
+        ),
+        pytest.param(
+            "3.11.0",
+            ">=3.0, <4.0",
+            True,
+            id="proposed version satisfies specifiers",
+        ),
+        pytest.param(
+            "4.0.0",
+            "!=4.0.0",
+            False,
+            id="proposed version excluded by specifiers",
+        ),
+        pytest.param(
+            "4.0.0",
+            ">=3.0",
+            True,
+            id="proposed version satisfies open-ended specifier",
+        ),
+        pytest.param(
+            "3.10.5",
+            "~=3.10.0",
+            True,
+            id="proposed version satisfies compatible release specifier",
+        ),
+        pytest.param(
+            "3.11.0",
+            "~=3.10.0",
+            False,
+            id="proposed version too distant for compatible release specifier",
+        ),
+        pytest.param(
+            "4.0.0",
+            ">>>invalid",
+            False,
+            id="invalid specifier returns False",
+        ),
+        pytest.param(
+            "not-a-version",
+            ">=3.0",
+            False,
+            id="unparseable proposed version returns False",
+        ),
+    ),
+)
+def test_check_accepted_version(
+    proposed_version,
+    version_update_specifiers,
+    exp,
+):
+    package_config = flexmock(
+        version_update_specifiers=version_update_specifiers,
+    )
+    config = Config()
+
+    assert (
+        PackitAPI(config, package_config).check_accepted_version(
+            proposed_version,
+        )
+        == exp
+    )
+
+
+@pytest.mark.parametrize(
     "package_name, version, response, result",
     (
         pytest.param(


### PR DESCRIPTION
Fixes https://github.com/packit/packit/issues/2191.

RELEASE NOTES BEGIN

In addition to `version_update_mask`, users can now use a new `version_update_specifiers` configuration option to control the upstream versions allowed to be release-synced. The option accepts [PEP440 version specifier sets](https://packaging.pypa.io/en/stable/specifiers.html), for example `version_update_specifiers: >=1.0,~=1.0`.

RELEASE NOTES END
