### PR TITLE
fix(cli): allow adjustment of ‹update_release›

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -2104,6 +2104,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         self,
         upstream_ref: Optional[str] = None,
         rpm_dir: Optional[str] = None,
+        update_release: Optional[bool] = None,
         release_suffix: Optional[str] = None,
         merged_ref: Optional[str] = None,
     ) -> list[Path]:
@@ -2113,12 +2114,16 @@ The first dist-git commit to be synced is '{short_hash}'.
         Args:
             upstream_ref: Git reference to the upstream commit.
             rpm_dir: Path to the directory where the RPMs are meant to be placed.
+            update_release: Whether to change Release in the spec-file.
             release_suffix: Release suffix that is used during modification of specfile.
             merged_ref: git ref in the upstream repo used to identify correct most recent tag
 
         Returns:
             List of paths to the built RPMs.
         """
+        if update_release is None:
+            update_release = self.package_config.update_release
+
         self.up.actions_handler.run_action(
             actions=ActionName.post_upstream_clone,
             env=self.common_env(),
@@ -2130,6 +2135,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         try:
             self.up.prepare_upstream_for_srpm_creation(
                 upstream_ref=upstream_ref,
+                update_release=update_release,
                 release_suffix=release_suffix,
                 merged_ref=merged_ref,
                 env=self.common_env(),

--- a/packit/cli/builds/local_build.py
+++ b/packit/cli/builds/local_build.py
@@ -19,7 +19,13 @@ from packit.utils.changelog_helper import ChangelogHelper
 logger = logging.getLogger("packit")
 
 
-def build_rpms_from_specfile(api, upstream_ref, release_suffix, default_release_suffix):
+def build_rpms_from_specfile(
+    api,
+    upstream_ref,
+    update_release,
+    release_suffix,
+    default_release_suffix,
+):
     """
     Build RPMs from the specfile definition and return the paths to the built RPMs.
     """
@@ -31,6 +37,7 @@ def build_rpms_from_specfile(api, upstream_ref, release_suffix, default_release_
 
     return api.create_rpms(
         upstream_ref=upstream_ref,
+        update_release=update_release,
         release_suffix=release_suffix,
     )
 
@@ -58,6 +65,14 @@ def log_rpms(rpms):
     help="Git ref of the last upstream commit in the current branch "
     "from which packit should generate patches "
     "(this option implies the repository is source-git).",
+)
+@click.option(
+    "--update-release/--no-update-release",
+    default=None,
+    help=(
+        "Specifies whether to update Release. "
+        "Defaults to value set in configuration, which defaults to yes."
+    ),
 )
 @click.option(
     "--release-suffix",
@@ -92,6 +107,7 @@ def log_rpms(rpms):
 def local(
     config,
     upstream_ref,
+    update_release,
     release_suffix,
     default_release_suffix,
     package_config,
@@ -115,6 +131,7 @@ def local(
         else build_rpms_from_specfile(
             api,
             upstream_ref,
+            update_release,
             release_suffix,
             default_release_suffix,
         )


### PR DESCRIPTION
1. Allow adjusting it via the CLI option
2. If not specified, default to the value in the config

<!-- TODO list -->

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
  - tests should've prevented this issue in the first place and I don't see much value in testing that the switch gets propagated through the cascade of calls… I appreciate counter-arguments to this though :)
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.
  - will be updated automatically with the script 

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #2711
Fixes PACKIT-4920

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit CLI has a new option `--[no-]update-release` that, by default, follows the value of the option set in the config, and also allows you to override manually, if necessary.

RELEASE NOTES END
