### PR TITLE
ci: disable OBS smoke test (401 Unauthorized)

### DIFF
--- a/.github/workflows/obs-build-smoke-test.yml
+++ b/.github/workflows/obs-build-smoke-test.yml
@@ -10,6 +10,10 @@ on:
 
 jobs:
   build-packit-in-obs:
+    # disabled for now because it's failing to auth with OBS
+    #   HTTP Error 401: Unauthorized
+    #   https://github.com/packit/packit/issues/2398
+    if: false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The OBS smoke test is currently failing with `HTTP Error 401: Unauthorized`
when authenticating with api.opensuse.org. Disabling it with `if: false`
until the credentials are fixed.

Related: #2398

Example:
<img width="1669" height="174" alt="image" src="https://github.com/user-attachments/assets/d98436a3-659b-477e-a948-f95d3b20c952" />

RELEASE NOTES BEGIN

Empty on purpose

RELEASE NOTES END