### PR TITLE
Mitigate chroot race condition in multi-package Copr projects

### DIFF
--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -26,6 +26,8 @@ from packit.local_project import LocalProject
 
 logger = logging.getLogger(__name__)
 
+_MAX_PROJECT_EDIT_RETRIES = 3
+
 
 def not_copr_race_condition(e):
     is_race_condition = "already exists" in str(e) and "400" in str(e)
@@ -274,23 +276,49 @@ class CoprHelper:
             logger.error(ex.result)
             raise PackitCoprProjectException(error) from ex
 
-        fields_to_change = self.get_fields_to_change(
-            copr_proj=copr_proj,
-            additional_repos=additional_repos,
-            chroots=chroots,
-            description=description,
-            instructions=instructions,
-            list_on_homepage=list_on_homepage,
-            delete_after_days=delete_after_days,
-            module_hotfixes=module_hotfixes,
-            bootstrap=bootstrap,
-        )
+        fields_to_change: dict[str, Any] = {}
+        failure_message = f"Copr project update failed for '{owner}/{project}' project."
         try:
-            if fields_to_change:
+            # Re-read project state and retry on chroot conflicts caused by
+            # concurrent tasks (multiple packages sharing the same Copr project).
+            for attempt in range(_MAX_PROJECT_EDIT_RETRIES):
+                copr_proj = self.copr_client.project_proxy.get(
+                    ownername=owner,
+                    projectname=project,
+                )
+                fields_to_change = self.get_fields_to_change(
+                    copr_proj=copr_proj,
+                    additional_repos=additional_repos,
+                    chroots=chroots,
+                    description=description,
+                    instructions=instructions,
+                    list_on_homepage=list_on_homepage,
+                    delete_after_days=delete_after_days,
+                    module_hotfixes=module_hotfixes,
+                    bootstrap=bootstrap,
+                )
+                if not fields_to_change:
+                    break
+
                 failure_message = (
                     f"Copr project update failed for '{owner}/{project}' project."
                 )
-                self.update_copr_project(owner, project, fields_to_change)
+                try:
+                    self.update_copr_project(owner, project, fields_to_change)
+                    break
+                except CoprRequestException as ex:
+                    if (
+                        "Can't drop chroot" in str(ex)
+                        and attempt < _MAX_PROJECT_EDIT_RETRIES - 1
+                    ):
+                        logger.warning(
+                            f"Copr project edit conflict on attempt "
+                            f"{attempt + 1}/{_MAX_PROJECT_EDIT_RETRIES}, "
+                            f"re-reading project state and retrying: {ex}",
+                        )
+                        time.sleep(3)
+                        continue
+                    raise
 
             failure_message = (
                 f"Copr project chroot configuration update failed "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,9 @@ from bugzilla import Bugzilla
 from deepdiff import DeepDiff
 from flexmock import flexmock
 
+import packit.config.aliases
 from packit.config import JobConfig, PackageConfig
+from packit.config.aliases import Distro
 from packit.utils.commands import cwd
 from packit.utils.repo import create_new_repo
 from tests.spellbook import (
@@ -30,6 +32,57 @@ from tests.spellbook import (
 @pytest.fixture(autouse=True)
 def bugzilla_mock():
     flexmock(Bugzilla).new_instances(flexmock(query=lambda *_, **__: []))
+
+
+@pytest.fixture()
+def mock_get_aliases():
+    flexmock(packit.config.aliases).should_receive("get_aliases").and_return(
+        {
+            "fedora-all": [
+                Distro("fedora-29", "f29"),
+                Distro("fedora-30", "f30"),
+                Distro("fedora-31", "f31"),
+                Distro("fedora-32", "f32"),
+                Distro("fedora-33", "f33"),
+                Distro("fedora-rawhide", "rawhide"),
+            ],
+            "fedora-stable": [Distro("fedora-31", "f31"), Distro("fedora-32", "f32")],
+            "fedora-branched": [Distro("fedora-33", "f33")],
+            "fedora-development": [
+                Distro("fedora-33", "f33"),
+                Distro("fedora-rawhide", "rawhide"),
+            ],
+            "epel-all": [
+                Distro("epel-6", "el6"),
+                Distro("epel-7", "epel7"),
+                Distro("epel-8", "epel8"),
+                Distro("epel-9", "epel9"),
+                Distro("epel-10.0", "epel10.0"),
+                Distro("epel-10.1", "epel10"),
+            ],
+            "epel-10-all": [
+                Distro("epel-10.0", "epel10.0"),
+                Distro("epel-10.1", "epel10"),
+            ],
+            "epel-10-branched": [
+                Distro("epel-10.0", "epel10.0"),
+            ],
+            "epel-10": [
+                Distro("epel-10.1", "epel10"),
+            ],
+            "opensuse-leap-all": [
+                "opensuse-leap-15.5",
+                "opensuse-leap-15.4",
+                "opensuse-leap-15.3",
+            ],
+            "opensuse-all": [
+                "opensuse-tumbleweed",
+                "opensuse-leap-15.5",
+                "opensuse-leap-15.4",
+                "opensuse-leap-15.3",
+            ],
+        },
+    )
 
 
 def get_git_repo_and_remote(

--- a/tests/integration/test_copr_build.py
+++ b/tests/integration/test_copr_build.py
@@ -546,7 +546,11 @@ def test_copr_build_no_owner(cwd_upstream_or_distgit, api_instance):
     assert "owner not set" in str(ex)
 
 
-def test_copr_build_cli_no_project_configured(upstream_and_remote, copr_client_mock):
+def test_copr_build_cli_no_project_configured(
+    upstream_and_remote,
+    copr_client_mock,
+    mock_get_aliases,
+):
     upstream, _ = upstream_and_remote
     flexmock(PackitAPI).should_receive("run_copr_build").with_args(
         project="packit-cli-upstream_remote-upstream_git-main",
@@ -574,7 +578,11 @@ def test_copr_build_cli_no_project_configured(upstream_and_remote, copr_client_m
     run_packit(["build", "in-copr", "--no-wait"], working_dir=upstream)
 
 
-def test_copr_build_cli_project_set_via_cli(upstream_and_remote, copr_client_mock):
+def test_copr_build_cli_project_set_via_cli(
+    upstream_and_remote,
+    copr_client_mock,
+    mock_get_aliases,
+):
     upstream, _ = upstream_and_remote
     flexmock(PackitAPI).should_receive("run_copr_build").with_args(
         project="the-project",
@@ -605,7 +613,11 @@ def test_copr_build_cli_project_set_via_cli(upstream_and_remote, copr_client_moc
     )
 
 
-def test_copr_build_cli_project_set_from_config(upstream_and_remote, copr_client_mock):
+def test_copr_build_cli_project_set_from_config(
+    upstream_and_remote,
+    copr_client_mock,
+    mock_get_aliases,
+):
     upstream, _ = upstream_and_remote
 
     flexmock(PackageConfig).should_receive("get_copr_build_project_value").and_return(

--- a/tests/integration/test_copr_build.py
+++ b/tests/integration/test_copr_build.py
@@ -31,18 +31,18 @@ def test_copr_build_existing_project(cwd_upstream_or_distgit, api_instance):
     instructions = "the instructions"
     chroots = ["fedora-rawhide-x86_64"]
 
-    flexmock(ProjectProxy).should_receive("add").and_return(
-        flexmock(
-            chroot_repos=flexmock(keys=lambda: chroots),
-            description=description,
-            instructions=instructions,
-            unlisted_on_hp=True,
-            delete_after_days=60,
-            additional_repos=[],
-            ownername=owner,
-            module_hotfixes=False,
-        ),
+    project_mock = flexmock(
+        chroot_repos=flexmock(keys=lambda: chroots),
+        description=description,
+        instructions=instructions,
+        unlisted_on_hp=True,
+        delete_after_days=60,
+        additional_repos=[],
+        ownername=owner,
+        module_hotfixes=False,
     )
+    flexmock(ProjectProxy).should_receive("add").and_return(project_mock)
+    flexmock(ProjectProxy).should_receive("get").and_return(project_mock)
 
     # no change in settings => no edit
     flexmock(ProjectProxy).should_receive("edit").times(0)
@@ -80,18 +80,18 @@ def test_copr_build_existing_project_change_settings(
     instructions = "the instructions"
     chroots = ["fedora-rawhide-x86_64"]
 
-    flexmock(ProjectProxy).should_receive("add").and_return(
-        flexmock(
-            chroot_repos=flexmock(keys=lambda: chroots),
-            description=description,
-            instructions=instructions,
-            unlisted_on_hp=True,
-            delete_after_days=60,
-            additional_repos=[],
-            ownername=owner,
-            module_hotfixes=False,
-        ),
+    project_mock = flexmock(
+        chroot_repos=flexmock(keys=lambda: chroots),
+        description=description,
+        instructions=instructions,
+        unlisted_on_hp=True,
+        delete_after_days=60,
+        additional_repos=[],
+        ownername=owner,
+        module_hotfixes=False,
     )
+    flexmock(ProjectProxy).should_receive("add").and_return(project_mock)
+    flexmock(ProjectProxy).should_receive("get").and_return(project_mock)
 
     flexmock(ProjectProxy).should_receive(
         "edit",
@@ -151,28 +151,28 @@ def test_copr_build_existing_project_munch_no_settings_change(
     project = "project-name"
     chroots = ["fedora-rawhide-x86_64"]
 
-    flexmock(ProjectProxy).should_receive("add").and_return(
-        munchify(
-            {
-                "additional_repos": [],
-                "auto_prune": True,
-                "chroot_repos": {
-                    "fedora-rawhide-x86_64": "https://download.copr.fedorainfracloud.org/"
-                    "results/packit/packit-hello-world-127-stg/fedora-rawhide-x86_64/",
-                },
-                "contact": "https://github.com/packit/packit/issues",
-                "description": "Continuous builds initiated by packit service.\n"
-                "For more info check out https://packit.dev/",
-                "devel_mode": False,
-                "enable_net": False,
-                "full_name": "packit/packit-hello-world-127-stg",
-                "homepage": "",
-                "id": 34245,
-                "ownername": owner,
-                "module_hotfixes": False,
+    project_mock = munchify(
+        {
+            "additional_repos": [],
+            "auto_prune": True,
+            "chroot_repos": {
+                "fedora-rawhide-x86_64": "https://download.copr.fedorainfracloud.org/"
+                "results/packit/packit-hello-world-127-stg/fedora-rawhide-x86_64/",
             },
-        ),
+            "contact": "https://github.com/packit/packit/issues",
+            "description": "Continuous builds initiated by packit service.\n"
+            "For more info check out https://packit.dev/",
+            "devel_mode": False,
+            "enable_net": False,
+            "full_name": "packit/packit-hello-world-127-stg",
+            "homepage": "",
+            "id": 34245,
+            "ownername": owner,
+            "module_hotfixes": False,
+        },
     )
+    flexmock(ProjectProxy).should_receive("add").and_return(project_mock)
+    flexmock(ProjectProxy).should_receive("get").and_return(project_mock)
 
     flexmock(ProjectProxy).should_receive("edit").and_return().times(0)
 
@@ -210,28 +210,28 @@ def test_copr_build_existing_project_munch_additional_repos_change(
     project = "project-name"
     chroots = ["fedora-rawhide-x86_64"]
 
-    flexmock(ProjectProxy).should_receive("add").and_return(
-        munchify(
-            {
-                "additional_repos": [],
-                "auto_prune": True,
-                "chroot_repos": {
-                    "fedora-rawhide-x86_64": "https://download.copr.fedorainfracloud.org/"
-                    "results/packit/packit-hello-world-127-stg/fedora-rawhide-x86_64/",
-                },
-                "contact": "https://github.com/packit/packit/issues",
-                "description": "Continuous builds initiated by packit service.\n"
-                "For more info check out https://packit.dev/",
-                "devel_mode": False,
-                "enable_net": False,
-                "full_name": "packit/packit-hello-world-127-stg",
-                "homepage": "",
-                "id": 34245,
-                "ownername": owner,
-                "module_hotfixes": False,
+    project_mock = munchify(
+        {
+            "additional_repos": [],
+            "auto_prune": True,
+            "chroot_repos": {
+                "fedora-rawhide-x86_64": "https://download.copr.fedorainfracloud.org/"
+                "results/packit/packit-hello-world-127-stg/fedora-rawhide-x86_64/",
             },
-        ),
+            "contact": "https://github.com/packit/packit/issues",
+            "description": "Continuous builds initiated by packit service.\n"
+            "For more info check out https://packit.dev/",
+            "devel_mode": False,
+            "enable_net": False,
+            "full_name": "packit/packit-hello-world-127-stg",
+            "homepage": "",
+            "id": 34245,
+            "ownername": owner,
+            "module_hotfixes": False,
+        },
     )
+    flexmock(ProjectProxy).should_receive("add").and_return(project_mock)
+    flexmock(ProjectProxy).should_receive("get").and_return(project_mock)
 
     flexmock(ProjectProxy).should_receive("edit").and_return().once()
 
@@ -273,28 +273,28 @@ def test_copr_build_existing_project_munch_list_on_homepage_change(
     project = "project-name"
     chroots = ["fedora-rawhide-x86_64"]
 
-    flexmock(ProjectProxy).should_receive("add").and_return(
-        munchify(
-            {
-                "additional_repos": [],
-                "auto_prune": True,
-                "chroot_repos": {
-                    "fedora-rawhide-x86_64": "https://download.copr.fedorainfracloud.org/"
-                    "results/packit/packit-hello-world-127-stg/fedora-rawhide-x86_64/",
-                },
-                "contact": "https://github.com/packit/packit/issues",
-                "description": "Continuous builds initiated by packit service.\n"
-                "For more info check out https://packit.dev/",
-                "devel_mode": False,
-                "enable_net": False,
-                "full_name": "packit/packit-hello-world-127-stg",
-                "homepage": "",
-                "id": 34245,
-                "ownername": owner,
-                "module_hotfixes": False,
+    project_mock = munchify(
+        {
+            "additional_repos": [],
+            "auto_prune": True,
+            "chroot_repos": {
+                "fedora-rawhide-x86_64": "https://download.copr.fedorainfracloud.org/"
+                "results/packit/packit-hello-world-127-stg/fedora-rawhide-x86_64/",
             },
-        ),
+            "contact": "https://github.com/packit/packit/issues",
+            "description": "Continuous builds initiated by packit service.\n"
+            "For more info check out https://packit.dev/",
+            "devel_mode": False,
+            "enable_net": False,
+            "full_name": "packit/packit-hello-world-127-stg",
+            "homepage": "",
+            "id": 34245,
+            "ownername": owner,
+            "module_hotfixes": False,
+        },
     )
+    flexmock(ProjectProxy).should_receive("add").and_return(project_mock)
+    flexmock(ProjectProxy).should_receive("get").and_return(project_mock)
 
     # We don't get that value from Copr. => We can't check the change. => No edit.
     flexmock(ProjectProxy).should_receive("edit").and_return().times(0)
@@ -333,29 +333,29 @@ def test_copr_build_existing_project_munch_do_not_update_booleans_by_default(
     project = "project-name"
     chroots = ["fedora-rawhide-x86_64"]
 
-    flexmock(ProjectProxy).should_receive("add").and_return(
-        munchify(
-            {
-                "additional_repos": [],
-                "auto_prune": True,
-                "chroot_repos": {
-                    "fedora-rawhide-x86_64": "https://download.copr.fedorainfracloud.org/"
-                    "results/packit/packit-hello-world-127-stg/fedora-rawhide-x86_64/",
-                },
-                "contact": "https://github.com/packit-service/packit/issues",
-                "description": "Continuous builds initiated by packit service.\n"
-                "For more info check out https://packit.dev/",
-                "unlisted_on_hp": True,  # Value not present currently.
-                "devel_mode": False,
-                "enable_net": False,
-                "full_name": "packit/packit-hello-world-127-stg",
-                "homepage": "",
-                "id": 34245,
-                "ownername": owner,
-                "module_hotfixes": False,
+    project_mock = munchify(
+        {
+            "additional_repos": [],
+            "auto_prune": True,
+            "chroot_repos": {
+                "fedora-rawhide-x86_64": "https://download.copr.fedorainfracloud.org/"
+                "results/packit/packit-hello-world-127-stg/fedora-rawhide-x86_64/",
             },
-        ),
+            "contact": "https://github.com/packit-service/packit/issues",
+            "description": "Continuous builds initiated by packit service.\n"
+            "For more info check out https://packit.dev/",
+            "unlisted_on_hp": True,  # Value not present currently.
+            "devel_mode": False,
+            "enable_net": False,
+            "full_name": "packit/packit-hello-world-127-stg",
+            "homepage": "",
+            "id": 34245,
+            "ownername": owner,
+            "module_hotfixes": False,
+        },
     )
+    flexmock(ProjectProxy).should_receive("add").and_return(project_mock)
+    flexmock(ProjectProxy).should_receive("get").and_return(project_mock)
 
     # Even if we receive this info from Copr, we can't edit that value if it is `None`.
     flexmock(ProjectProxy).should_receive("edit").and_return().times(0)
@@ -410,31 +410,31 @@ def test_copr_build_existing_project_munch_chroot_updates(
     u, d, api = api_instance
     project = "project-name"
 
-    flexmock(ProjectProxy).should_receive("add").and_return(
-        munchify(
-            {
-                "additional_repos": [],
-                "auto_prune": True,
-                "chroot_repos": {
-                    "fedora-rawhide-x86_64": "https://download.copr.fedorainfracloud.org/"
-                    "results/packit/packit-hello-world-127-stg/fedora-rawhide-x86_64/",
-                    "epel-8-x86_64": "https://download.copr.fedorainfracloud.org/"
-                    "results/packit/packit-hello-world-127-stg/epel-8-x86_64/",
-                },
-                "contact": "https://github.com/packit-service/packit/issues",
-                "description": "Continuous builds initiated by packit service.\n"
-                "For more info check out https://packit.dev/",
-                "unlisted_on_hp": True,  # Value not present currently.
-                "devel_mode": False,
-                "enable_net": False,
-                "full_name": "packit/packit-hello-world-127-stg",
-                "homepage": "",
-                "id": 34245,
-                "ownername": owner,
-                "module_hotfixes": False,
+    project_mock = munchify(
+        {
+            "additional_repos": [],
+            "auto_prune": True,
+            "chroot_repos": {
+                "fedora-rawhide-x86_64": "https://download.copr.fedorainfracloud.org/"
+                "results/packit/packit-hello-world-127-stg/fedora-rawhide-x86_64/",
+                "epel-8-x86_64": "https://download.copr.fedorainfracloud.org/"
+                "results/packit/packit-hello-world-127-stg/epel-8-x86_64/",
             },
-        ),
+            "contact": "https://github.com/packit-service/packit/issues",
+            "description": "Continuous builds initiated by packit service.\n"
+            "For more info check out https://packit.dev/",
+            "unlisted_on_hp": True,  # Value not present currently.
+            "devel_mode": False,
+            "enable_net": False,
+            "full_name": "packit/packit-hello-world-127-stg",
+            "homepage": "",
+            "id": 34245,
+            "ownername": owner,
+            "module_hotfixes": False,
+        },
     )
+    flexmock(ProjectProxy).should_receive("add").and_return(project_mock)
+    flexmock(ProjectProxy).should_receive("get").and_return(project_mock)
 
     if expected_chroots_for_edit:
         expected_chroots_for_edit.sort()
@@ -482,18 +482,18 @@ def test_copr_build_existing_project_error_on_change_settings(
     instructions = "the instructions"
     chroots = ["fedora-rawhide-x86_64"]
 
-    flexmock(ProjectProxy).should_receive("add").and_return(
-        flexmock(
-            chroot_repos=flexmock(keys=lambda: chroots),
-            description=description,
-            instructions=instructions,
-            unlisted_on_hp=True,
-            delete_after_days=60,
-            additional_repos=[],
-            ownername=owner,
-            module_hotfixes=False,
-        ),
+    project_mock = flexmock(
+        chroot_repos=flexmock(keys=lambda: chroots),
+        description=description,
+        instructions=instructions,
+        unlisted_on_hp=True,
+        delete_after_days=60,
+        additional_repos=[],
+        ownername=owner,
+        module_hotfixes=False,
     )
+    flexmock(ProjectProxy).should_receive("add").and_return(project_mock)
+    flexmock(ProjectProxy).should_receive("get").and_return(project_mock)
 
     flexmock(ProjectProxy).should_receive("request_permissions").with_args(
         ownername=owner,
@@ -653,13 +653,17 @@ def test_create_or_update_copr_project(copr_client_mock):
         "module_hotfixes": None,
     }
 
+    project_result = flexmock(
+        chroot_repos={"centos-stream-8-x86_64": "https://repo.url"},
+        **options,
+    )
     copr_client_mock.project_proxy = flexmock()
     copr_client_mock.project_chroot_proxy = flexmock()
     flexmock(copr_client_mock.project_proxy).should_receive("add").and_return(
-        flexmock(
-            chroot_repos={"centos-stream-8-x86_64": "https://repo.url"},
-            **options,
-        ),
+        project_result,
+    )
+    flexmock(copr_client_mock.project_proxy).should_receive("get").and_return(
+        project_result,
     )
     flexmock(copr_client_mock.project_chroot_proxy).should_receive("get").and_return(
         {"additional_packages": []},
@@ -690,15 +694,17 @@ def test_create_or_update_copr_project_race_condition(copr_client_mock):
         "module_hotfixes": None,
     }
 
+    project_result = flexmock(
+        chroot_repos={"centos-stream-8-x86_64": "https://repo.url"},
+        **options,
+    )
     copr_client_mock.project_proxy = flexmock()
     copr_client_mock.project_chroot_proxy = flexmock()
     flexmock(copr_client_mock.project_proxy).should_receive("add").twice().and_raise(
         PackitCoprProjectException("already exists, 400 BAD REQUEST"),
-    ).and_return(
-        flexmock(
-            chroot_repos={"centos-stream-8-x86_64": "https://repo.url"},
-            **options,
-        ),
+    ).and_return(project_result)
+    flexmock(copr_client_mock.project_proxy).should_receive("get").and_return(
+        project_result,
     )
     flexmock(copr_client_mock.project_chroot_proxy).should_receive("get").and_return(
         {"additional_packages": []},

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,67 +7,12 @@ from pathlib import Path
 import pytest
 from flexmock import flexmock
 
-import packit
-import packit.config.aliases
 from packit.config import Config
-from packit.config.aliases import Distro
 from packit.distgit import DistGit
 from packit.local_project import LocalProjectBuilder
 from packit.sync import SyncFilesItem
 from packit.upstream import GitUpstream
 from tests.spellbook import CRONIE, get_test_config, initiate_git_repo
-
-
-@pytest.fixture()
-def mock_get_aliases():
-    mock_aliases_module = flexmock(packit.config.aliases)
-    mock_aliases_module.should_receive("get_aliases").and_return(
-        {
-            "fedora-all": [
-                Distro("fedora-29", "f29"),
-                Distro("fedora-30", "f30"),
-                Distro("fedora-31", "f31"),
-                Distro("fedora-32", "f32"),
-                Distro("fedora-33", "f33"),
-                Distro("fedora-rawhide", "rawhide"),
-            ],
-            "fedora-stable": [Distro("fedora-31", "f31"), Distro("fedora-32", "f32")],
-            "fedora-branched": [Distro("fedora-33", "f33")],
-            "fedora-development": [
-                Distro("fedora-33", "f33"),
-                Distro("fedora-rawhide", "rawhide"),
-            ],
-            "epel-all": [
-                Distro("epel-6", "el6"),
-                Distro("epel-7", "epel7"),
-                Distro("epel-8", "epel8"),
-                Distro("epel-9", "epel9"),
-                Distro("epel-10.0", "epel10.0"),
-                Distro("epel-10.1", "epel10"),
-            ],
-            "epel-10-all": [
-                Distro("epel-10.0", "epel10.0"),
-                Distro("epel-10.1", "epel10"),
-            ],
-            "epel-10-branched": [
-                Distro("epel-10.0", "epel10.0"),
-            ],
-            "epel-10": [
-                Distro("epel-10.1", "epel10"),
-            ],
-            "opensuse-leap-all": [
-                "opensuse-leap-15.5",
-                "opensuse-leap-15.4",
-                "opensuse-leap-15.3",
-            ],
-            "opensuse-all": [
-                "opensuse-tumbleweed",
-                "opensuse-leap-15.5",
-                "opensuse-leap-15.4",
-                "opensuse-leap-15.3",
-            ],
-        },
-    )
 
 
 @pytest.fixture

--- a/tests/unit/test_copr_helper.py
+++ b/tests/unit/test_copr_helper.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: MIT
 
 import pytest
+from copr.v3.exceptions import CoprRequestException
 from flexmock import flexmock
 
 import packit
-from packit.copr_helper import CoprHelper
+from packit.copr_helper import _MAX_PROJECT_EDIT_RETRIES, CoprHelper
 
 
 class TestCoprHelper:
@@ -165,3 +166,123 @@ class TestCoprHelper:
             )
             == result_dict
         )
+
+
+class TestCoprProjectEditRetry:
+    """Tests for the retry logic in create_or_update_copr_project
+    when concurrent tasks cause chroot conflicts."""
+
+    @staticmethod
+    def _make_copr_helper():
+        project_proxy_mock = flexmock()
+        copr_client_mock = flexmock(
+            config={"copr_url": "https://fedoracloud.org"},
+            project_proxy=project_proxy_mock,
+            project_chroot_proxy=flexmock(),
+        )
+        flexmock(packit.copr_helper.CoprClient).should_receive(
+            "create_from_config_file",
+        ).and_return(copr_client_mock)
+
+        upstream_mock = flexmock(git_url="https://github.com/test/test.git")
+        copr_helper = CoprHelper(upstream_mock)
+        return copr_helper, project_proxy_mock
+
+    @staticmethod
+    def _make_project_mock(**chroot_repos):
+        return flexmock(
+            chroot_repos=chroot_repos,
+            description="test",
+            unlisted_on_hp=True,
+            delete_after_days=60,
+            additional_repos=[],
+            module_hotfixes=False,
+            bootstrap="default",
+        )
+
+    def test_project_edit_retries_on_chroot_conflict(self):
+        copr_helper, project_proxy = self._make_copr_helper()
+
+        # Stale snapshot: missing centos chroot added by a concurrent task
+        project_stale = self._make_project_mock(
+            **{"fedora-rawhide-x86_64": "http://repo/fedora-rawhide-x86_64"},
+        )
+        # Fresh re-read: now includes centos (added by concurrent task),
+        # but still missing fedora-44 (the chroot we need to add)
+        project_fresh = self._make_project_mock(
+            **{
+                "fedora-rawhide-x86_64": "http://repo/fedora-rawhide-x86_64",
+                "centos-stream-10-x86_64": "http://repo/centos-stream-10-x86_64",
+            },
+        )
+
+        project_proxy.should_receive("add").and_return(project_stale).once()
+        project_proxy.should_receive("get").and_return(
+            project_stale,
+        ).and_return(project_fresh).twice()
+
+        project_proxy.should_receive("edit").and_raise(
+            CoprRequestException(
+                "Can't drop chroot from project, related build 123 is still in progress",
+            ),
+        ).and_return(None).twice()
+
+        flexmock(packit.copr_helper.time).should_receive("sleep").once()
+
+        copr_helper.create_or_update_copr_project(
+            project="test-project",
+            chroots=["fedora-rawhide-x86_64", "fedora-44-x86_64"],
+            owner="packit",
+        )
+
+    def test_project_edit_raises_after_max_retries(self):
+        copr_helper, project_proxy = self._make_copr_helper()
+
+        project_mock = self._make_project_mock(
+            **{"fedora-rawhide-x86_64": "http://repo/fedora-rawhide-x86_64"},
+        )
+
+        project_proxy.should_receive("add").and_return(project_mock).once()
+        project_proxy.should_receive("get").and_return(
+            project_mock,
+        ).times(_MAX_PROJECT_EDIT_RETRIES)
+
+        project_proxy.should_receive("edit").and_raise(
+            CoprRequestException(
+                "Can't drop chroot from project, related build 123 is still in progress",
+            ),
+        ).times(_MAX_PROJECT_EDIT_RETRIES)
+
+        flexmock(packit.copr_helper.time).should_receive("sleep").times(
+            _MAX_PROJECT_EDIT_RETRIES - 1,
+        )
+
+        with pytest.raises(CoprRequestException, match="Can't drop chroot"):
+            copr_helper.create_or_update_copr_project(
+                project="test-project",
+                chroots=["fedora-rawhide-x86_64", "fedora-44-x86_64"],
+                owner="packit",
+            )
+
+    def test_project_edit_does_not_retry_other_errors(self):
+        copr_helper, project_proxy = self._make_copr_helper()
+
+        project_mock = self._make_project_mock(
+            **{"fedora-rawhide-x86_64": "http://repo/fedora-rawhide-x86_64"},
+        )
+
+        project_proxy.should_receive("add").and_return(project_mock).once()
+        project_proxy.should_receive("get").and_return(project_mock).once()
+
+        project_proxy.should_receive("edit").and_raise(
+            CoprRequestException("Unable to connect to Copr"),
+        ).once()
+
+        flexmock(packit.copr_helper.time).should_receive("sleep").never()
+
+        with pytest.raises(CoprRequestException, match="Unable to connect"):
+            copr_helper.create_or_update_copr_project(
+                project="test-project",
+                chroots=["fedora-rawhide-x86_64", "fedora-44-x86_64"],
+                owner="packit",
+            )


### PR DESCRIPTION
Projects with multiple packages (monorepo) and multiple `copr_build` jobs with `pull_request` trigger, where each job has a different set of targets, are subject to race condition when one job extends the list of chroots of the project but other job reads the list of chroots before that happens and thus attempts to drop chroots used by now-running build (corresponding to the first job). Fix that by re-reading the list of chroots immediately before each edit and retrying up to 3 times on chroot conflict errors.
