### PR TITLE
Force checkout target branch in merge_pr

### DIFF
--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -543,7 +543,7 @@ class LocalProject:
             f"refs/remotes/{remote}/pr/{pr_id}",
             target_branch_name,
         )
-        self.git_repo.branches[target_branch_name].checkout()
+        self.git_repo.branches[target_branch_name].checkout(force=True)
         target_branch = self.git_repo.branches[target_branch_name]
 
         commit_sha = shorten_commit_hash(target_branch.commit.hexsha)


### PR DESCRIPTION
Fixes #2733

## Description

When a PR modifies vendored files (e.g. Go dependency bumps via Dependabot), `merge_pr()` in `local_project.py` fails because `git checkout` refuses to switch from the PR branch to the target branch. Git sees the vendored file differences between branches as uncommitted local modifications and aborts:
```
error: Your local changes to the following files would be overwritten by checkout:
    vendor/...
Please commit your changes or stash them before you switch branches.
Aborting
```

This is the same class of bug fixed in #1645 / #1693 for the `propose-downstream` code path, where the checkout in `sync_release()` was changed to use `-f`. This PR applies the same fix to `merge_pr()` by passing `force=True` to the GitPython `checkout()` call.

## How to reproduce

1. A Go project with `vendor/` committed and `%goprep -k` in the RPM spec
2. A Dependabot PR that bumps a dependency, causing `go mod vendor` to update files in transitive dependencies (e.g. LICENSE or README formatting changes)
3. Packit's `copr_build` job triggers on the PR
4. `prepare-sources` checks out the PR branch, then `merge_pr()` attempts to checkout the target branch
5. The checkout fails because vendored files differ between branches

## Change

One-line fix in `packit/local_project.py:546`:

```diff
-        self.git_repo.branches[target_branch_name].checkout()
+        self.git_repo.branches[target_branch_name].checkout(force=True)
```
RELEASE NOTES BEGIN
The merge_pr() method now force-checks out the target branch, fixing SRPM build failures on PRs that modify vendored dependency files.
RELEASE NOTES END
