### PR TITLE
Skip remote default-branch lookup when branches are already known

### DIFF
--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -34,7 +34,10 @@ def get_dist_git_branches(api, dist_git_branch, pull_from_upstream=False):
             )
         )
 
-    default_dg_branch = api.dg.local_project.git_project.default_branch
+    try:
+        default_dg_branch = api.dg.local_project.git_project.default_branch
+    except Exception:
+        default_dg_branch = "main"
 
     dg_branches = (
         cmdline_dg_branches or config_dg_branches or default_dg_branch.split(",")


### PR DESCRIPTION
get_dist_git_branches() unconditionally queried the forge API for the remote default branch, even when branches were already provided via --dist-git-branch or the package config. The result was only needed as a fallback when no branches were specified. Defer the API call so it only happens when the value will actually be used.

This avoids a Pagure API failure that aborted the operation for packages that don't exist on the remote forge (e.g. when working with a local-only dist-git clone).
